### PR TITLE
Update Imperium - Grey Knights.cat

### DIFF
--- a/Imperium - Grey Knights.cat
+++ b/Imperium - Grey Knights.cat
@@ -4248,10 +4248,10 @@
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Purgation Squad" hidden="false" id="e8ad-bd40-5952-6859">
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="165"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="190"/>
       </costs>
       <modifiers>
-        <modifier type="set" value="275" field="51b2-306e-1021-d207">
+        <modifier type="set" value="320" field="51b2-306e-1021-d207">
           <conditions>
             <condition type="atLeast" value="6" field="selections" scope="e8ad-bd40-5952-6859" childId="model" shared="true"/>
           </conditions>


### PR DESCRIPTION
Fix issues with Grey Knight Purgation Squad costs. They were updated with the Munitorum Field Manual 1.2 update.

Fix for Grey Knight Purgation Squad - Incorrect Point Costs #24