### PR TITLE
Fix the Primaris Apothecary wargear

### DIFF
--- a/Imperium - Space Marines.cat
+++ b/Imperium - Space Marines.cat
@@ -13643,7 +13643,7 @@ model is within 12&quot;.</characteristic>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4e88-a401-ed8a-8de"/>
           </constraints>
         </entryLink>
-        <entryLink import="true" name="Absolver Bolt Pistol" hidden="false" type="selectionEntry" id="b75-79bb-8f05-9ec4" targetId="a490-361-c9c4-afeb">
+        <entryLink import="true" name="Absolvor Bolt Pistol" hidden="false" type="selectionEntry" id="b75-79bb-8f05-9ec4" targetId="a490-361-c9c4-afeb">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="609a-6258-f8dc-2078"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2793-19ad-bcf6-1561"/>
@@ -13694,9 +13694,9 @@ model is within 12&quot;.</characteristic>
         </profile>
       </profiles>
     </selectionEntry>
-    <selectionEntry type="upgrade" import="true" name="Absolver Bolt Pistol" hidden="false" id="a490-361-c9c4-afeb">
+    <selectionEntry type="upgrade" import="true" name="Absolvor Bolt Pistol" hidden="false" id="a490-361-c9c4-afeb">
       <profiles>
-        <profile name="Absolver Bolt Pistol" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="cb64-ddb1-cbc3-3621">
+        <profile name="Absolvor Bolt Pistol" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="cb64-ddb1-cbc3-3621">
           <characteristics>
             <characteristic name="Range" typeId="9896-9419-16a1-92fc">18&quot;</characteristic>
             <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
@@ -13816,7 +13816,7 @@ model is within 12&quot;.</characteristic>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="74c4-d254-4750-6275"/>
           </constraints>
         </entryLink>
-        <entryLink import="true" name="Absolver Bolt Pistol" hidden="false" type="selectionEntry" id="ef74-78ef-da87-3eb0" targetId="a490-361-c9c4-afeb">
+        <entryLink import="true" name="Absolvor Bolt Pistol" hidden="false" type="selectionEntry" id="ef74-78ef-da87-3eb0" targetId="a490-361-c9c4-afeb">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d690-9e59-95d0-4b54"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8a68-ffb9-7225-4974"/>
@@ -14799,7 +14799,7 @@ Attacks characteristic of 7.</characteristic>
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad60-fb6-5cf4-f118" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink import="true" name="Absolver Bolt Pistol" hidden="false" type="selectionEntry" id="7c7b-e0a5-f7ce-a060" targetId="a490-361-c9c4-afeb">
+        <entryLink import="true" name="Absolvor Bolt Pistol" hidden="false" type="selectionEntry" id="7c7b-e0a5-f7ce-a060" targetId="a490-361-c9c4-afeb">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3213-f7c3-bd39-66ad"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d5cd-f45e-2efa-b3dd"/>
@@ -14907,7 +14907,7 @@ You can attach this model to one of the above units even if one Captain, Chapte
       </infoLinks>
       <entryLinks>
         <entryLink id="15f1-f783-aee4-f802" name="Warlord" hidden="false" collective="false" import="true" targetId="caa-f869-3cbd-b48e" type="selectionEntry"/>
-        <entryLink import="true" name="Absolver Bolt Pistol" hidden="false" type="selectionEntry" id="55c0-7a85-42af-ef54" targetId="a490-361-c9c4-afeb">
+        <entryLink import="true" name="Absolvor Bolt Pistol" hidden="false" type="selectionEntry" id="55c0-7a85-42af-ef54" targetId="a490-361-c9c4-afeb">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="bcb0-9a0b-78c-6fa7"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="972d-ea0a-a71d-314d"/>
@@ -15654,7 +15654,7 @@ You can attach this model to one of the above units even if one Captain, Chapte
         </profile>
       </profiles>
       <entryLinks>
-        <entryLink import="true" name="Absolver Bolt Pistol" hidden="false" type="selectionEntry" id="3125-bf-a712-d29f" targetId="a490-361-c9c4-afeb">
+        <entryLink import="true" name="Absolvor Bolt Pistol" hidden="false" type="selectionEntry" id="3125-bf-a712-d29f" targetId="a490-361-c9c4-afeb">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="2cb8-b8eb-3d60-4124"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e9db-1770-3ecd-8421"/>

--- a/Imperium - Space Marines.cat
+++ b/Imperium - Space Marines.cat
@@ -14869,7 +14869,7 @@ You can attach this model to one of the above units even if one Captain, Chapte
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="409f-19de-1608-29fc"/>
           </constraints>
           <profiles>
-            <profile name="Reductor Pistol" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="46d1-c07b-d1bb-4778">
+            <profile name="Reductor Pistol" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="46d1-c07b-d1bb-4778">
               <characteristics>
                 <characteristic name="Range" typeId="914c-b413-91e3-a132">3&quot;</characteristic>
                 <characteristic name="A" typeId="2337-daa1-6682-b110">1</characteristic>


### PR DESCRIPTION
This proposed update fixes two issues:

* Incorrect Absolvor bolt pistol name
* The Reductor pistol shown as a Melee Weapon in the roster