### PR TITLE
Update Jakhal points to change based unit size correctly

### DIFF
--- a/Chaos - World Eaters.cat
+++ b/Chaos - World Eaters.cat
@@ -2139,9 +2139,6 @@
                   </costs>
                 </selectionEntry>
               </selectionEntries>
-              <costs>
-                <cost name="pts" typeId="51b2-306e-1021-d207" value="70"/>
-              </costs>
             </selectionEntry>
             <selectionEntry id="c2d6-b088-fddb-cca6" name="C: 17 chainblades" hidden="false" collective="false" import="true" type="upgrade">
               <selectionEntries>
@@ -2159,9 +2156,6 @@
                   </costs>
                 </selectionEntry>
               </selectionEntries>
-              <costs>
-                <cost name="pts" typeId="51b2-306e-1021-d207" value="70"/>
-              </costs>
             </selectionEntry>
             <selectionEntry id="5b7f-e6b5-15e6-fbd8" name="B: 1 mauler chainblade, 7 chainblades" hidden="false" collective="false" import="true" type="upgrade">
               <selectionEntries>
@@ -2301,9 +2295,6 @@
                   </costs>
                 </selectionEntry>
               </selectionEntries>
-              <costs>
-                <cost name="pts" typeId="51b2-306e-1021-d207" value="70"/>
-              </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -2414,6 +2405,13 @@
       <costs>
         <cost name="pts" typeId="51b2-306e-1021-d207" value="70"/>
       </costs>
+      <modifiers>
+        <modifier type="set" value="140" field="51b2-306e-1021-d207">
+          <conditions>
+            <condition type="greaterThan" value="10" field="selections" scope="6f81-4538-a414-251e" childId="model" shared="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
     </selectionEntry>
     <selectionEntry id="32bc-0724-a7cf-f17c" name="Paired accursed weapons" hidden="false" collective="true" import="true" type="upgrade">
       <profiles>

--- a/Chaos - World Eaters.cat
+++ b/Chaos - World Eaters.cat
@@ -1994,13 +1994,6 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="6f81-4538-a414-251e" name="Jakhals" hidden="false" collective="false" import="true" type="unit">
-      <modifiers>
-        <modifier type="set" field="51b2-306e-1021-d207" value="140">
-          <conditions>
-            <condition field="selections" scope="6f81-4538-a414-251e" value="3" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="force" value="6" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0ce0-ebde-7eb7-c6ac" type="max"/>
       </constraints>
@@ -2147,7 +2140,7 @@
                 </selectionEntry>
               </selectionEntries>
               <costs>
-                <cost name="pts" typeId="51b2-306e-1021-d207" value="0"/>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="70"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c2d6-b088-fddb-cca6" name="C: 17 chainblades" hidden="false" collective="false" import="true" type="upgrade">
@@ -2167,7 +2160,7 @@
                 </selectionEntry>
               </selectionEntries>
               <costs>
-                <cost name="pts" typeId="51b2-306e-1021-d207" value="0"/>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="70"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="5b7f-e6b5-15e6-fbd8" name="B: 1 mauler chainblade, 7 chainblades" hidden="false" collective="false" import="true" type="upgrade">
@@ -2309,7 +2302,7 @@
                 </selectionEntry>
               </selectionEntries>
               <costs>
-                <cost name="pts" typeId="51b2-306e-1021-d207" value="0"/>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="70"/>
               </costs>
             </selectionEntry>
           </selectionEntries>


### PR DESCRIPTION
This fixes the Jakhals to check for 11+ models in the unit, instead of 4+, for calculating unit points.

fixes #629