### PR TITLE
Correction: Repulsor Executioner - Twin Icarus Ironhail Heavy Stubber…

### DIFF
--- a/Imperium - Space Marines.cat
+++ b/Imperium - Space Marines.cat
@@ -7143,7 +7143,7 @@ by 1.</characteristic>
             <characteristic name="A" typeId="3bb-c35f-f54-fb08">3</characteristic>
             <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
             <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
-            <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
+            <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
             <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
             <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Anti-fly 4+, Rapid Fire 3, Twin-linked</characteristic>
           </characteristics>


### PR DESCRIPTION
… AP from -1 to 0

New Recruit shows AP: -1
![B7972393-25A2-418F-8612-BE76B0657BF9_1_201_a](https://github.com/BSData/wh40k-10e/assets/34260365/6b9abaa3-55a2-46ee-ae7f-14d3e07238aa)

Warhammer 40k App shows AP: 0
![130EA450-D599-44F6-9069-6050F29099B8_1_201_a](https://github.com/BSData/wh40k-10e/assets/34260365/2425a60f-9a43-406b-80bb-5c8fb7b91af9)
