### PR TITLE
Update CSM points costs per Munitorum 1.8

### DIFF
--- a/Chaos - Chaos Space Marines.cat
+++ b/Chaos - Chaos Space Marines.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="c8da-e875-58f7-f6d6" name="Chaos - Chaos Space Marines" revision="44" battleScribeVersion="2.03" library="false" gameSystemId="sys-352e-adc2-7639-d6a9" gameSystemRevision="1" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="c8da-e875-58f7-f6d6" name="Chaos - Chaos Space Marines" revision="45" battleScribeVersion="2.03" library="false" gameSystemId="sys-352e-adc2-7639-d6a9" gameSystemRevision="1" type="catalogue">
   <profileTypes>
     <profileType id="3084-68b8-1d20-2f26" name="Marks of Chaos">
       <characteristicTypes>
@@ -1240,7 +1240,7 @@ A unit can only embark within (or start the battle embarked within) a TRANSPORT 
         <entryLink id="242f-eb21-ba0b-3b57" name="Allegiance" hidden="false" collective="false" import="true" targetId="5581-5d38-90b8-f8cd" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="180"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="165"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2a1d-2757-347c-58f2" name="Heretic Astartes Daemon Prince with wings" publicationId="48fc-15aa-b307-9443" hidden="false" collective="false" import="true" type="model">
@@ -1387,7 +1387,7 @@ A unit can only embark within (or start the battle embarked within) a TRANSPORT 
         <entryLink id="4d65-d4ed-1a4-3a73" name="Allegiance" hidden="false" collective="false" import="true" targetId="5581-5d38-90b8-f8cd" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="195"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="180"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="cd9c-96e7-6dcb-bedf" name="Fabius Bile" hidden="false" collective="false" import="true" type="unit">
@@ -1745,7 +1745,7 @@ A unit can only embark within (or start the battle embarked within) a TRANSPORT 
         <entryLink id="80a0-7a84-dd3-5f54" name="Warlord" hidden="false" collective="false" import="true" targetId="1a34-f1cc-ec01-ca32" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="105"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="90"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="287f-7d48-59cf-dc1e" name="Master of Possession" hidden="false" collective="false" import="true" type="model">
@@ -4321,7 +4321,7 @@ You can attach this model to one of the above units even if one other CHARACTER 
         <entryLink id="ed78-7994-335a-e389" name="Chaos icon" hidden="false" collective="false" import="true" targetId="4ea1-c93a-fc5a-9977" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="90"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="80"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="96f5-8be7-2cd8-f84f" name="Boltgun" hidden="false" collective="false" import="true" type="upgrade">
@@ -4750,7 +4750,7 @@ You can attach this model to one of the above units even if one other CHARACTER 
         <entryLink id="9c6-93be-cec9-3cdb" name="Allegiance" hidden="false" collective="false" import="true" targetId="5581-5d38-90b8-f8cd" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="55"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="50"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="23aa-b45a-6d5d-e92b" name="Accursed Cultists" hidden="false" collective="false" import="true" type="unit">
@@ -5191,7 +5191,7 @@ You can attach this model to one of the above units even if one other CHARACTER 
         <entryLink id="19b1-1a0f-3909-33b7" name="Allegiance" hidden="false" collective="false" import="true" targetId="5581-5d38-90b8-f8cd" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="195"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="185"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8094-a17b-7550-a066" name="Accursed weapon" hidden="false" collective="true" import="true" type="upgrade">
@@ -5500,7 +5500,7 @@ You can attach this model to one of the above units even if one other CHARACTER 
         <entryLink id="663d-4d7d-cd00-bb90" name="Chaos icon" hidden="false" collective="false" import="true" targetId="4ea1-c93a-fc5a-9977" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="140"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="130"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4e85-615b-5d49-dfa4" name="Chosen" hidden="false" collective="false" import="true" type="unit">
@@ -6272,7 +6272,7 @@ You can attach this model to one of the above units even if one other CHARACTER 
         <entryLink id="bf7e-5454-7c68-b77a" name="Allegiance" hidden="false" collective="false" import="true" targetId="5581-5d38-90b8-f8cd" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="120"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="110"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7373-47b7-11a3-2b48" name="Chaos Bikers" hidden="false" collective="false" import="true" type="unit">
@@ -6676,7 +6676,7 @@ You can attach this model to one of the above units even if one other CHARACTER 
         <entryLink id="69bf-4fb8-f1a5-ceae" name="Chaos icon" hidden="false" collective="false" import="true" targetId="4ea1-c93a-fc5a-9977" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="85"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="75"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3854-44a6-5746-d602" name="Close combat weapon" hidden="false" collective="true" import="true" type="upgrade">
@@ -6960,7 +6960,7 @@ You can attach this model to one of the above units even if one other CHARACTER 
         <entryLink id="cb07-b287-c4ff-5d84" name="Allegiance" hidden="false" collective="false" import="true" targetId="5581-5d38-90b8-f8cd" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="90"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="85"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="44ae-a376-590b-6349" name="Astartes chainsword" hidden="false" collective="false" import="true" type="upgrade">
@@ -7390,7 +7390,7 @@ You can attach this model to one of the above units even if one other CHARACTER 
         <entryLink id="c67d-35f7-6498-9ab6" name="Allegiance" hidden="false" collective="false" import="true" targetId="5581-5d38-90b8-f8cd" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="135"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="120"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2311-fa63-364-22a3" name="Obliterators" hidden="false" collective="false" import="true" type="unit">
@@ -9223,7 +9223,7 @@ You can attach this model to one of the above units even if one other CHARACTER 
         <entryLink id="e8d2-8c52-b95c-b03f" name="Mark of Chaos" hidden="false" collective="false" import="true" targetId="5581-5d38-90b8-f8cd" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="190"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="175"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7a72-5eae-45ca-7e8f" name="Defiler" hidden="false" collective="false" import="true" type="model">
@@ -9907,7 +9907,7 @@ You can attach this model to one of the above units even if one other CHARACTER 
         <entryLink id="9648-e14f-10c-c502" name="Mark of Chaos" hidden="false" collective="false" import="true" targetId="5581-5d38-90b8-f8cd" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="140"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="130"/>
       </costs>
       <selectionEntries>
         <selectionEntry type="upgrade" import="true" name="Close combat weapon" hidden="false" id="da4f-e317-2582-a402">
@@ -10185,7 +10185,7 @@ You can attach this model to one of the above units even if one other CHARACTER 
         <entryLink id="f1bc-aa05-a412-1660" name="Mark of Chaos" hidden="false" collective="false" import="true" targetId="5581-5d38-90b8-f8cd" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="155"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="140"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e981-27ae-112f-aa9a" name="Chaos Rhino" hidden="false" collective="false" import="true" type="model">

--- a/Chaos - Chaos Space Marines.cat
+++ b/Chaos - Chaos Space Marines.cat
@@ -116,10 +116,22 @@
     <entryLink id="2e42-8d21-37fe-1de9" name="Abaddon the Despoiler" hidden="false" collective="false" import="true" targetId="76b4-a2c4-208e-ceb9" type="selectionEntry"/>
     <entryLink id="566c-4189-2980-5264" name="Haarken Worldclaimer" hidden="false" collective="false" import="true" targetId="d93f-6d73-1792-cb18" type="selectionEntry"/>
     <entryLink id="14ab-9043-9077-770a" name="Huron Blackheart" hidden="false" collective="false" import="true" targetId="d9e3-8baf-128f-6389" type="selectionEntry"/>
-    <entryLink id="1dec-e057-8cae-c9ae" name="Heretic Astartes Daemon Prince" hidden="false" collective="false" import="true" targetId="9bbd-a535-a4ef-9680" type="selectionEntry"/>
-    <entryLink id="1087-e992-6b82-3b8" name="Heretic Astartes Daemon Prince with wings" hidden="false" collective="false" import="true" targetId="2a1d-2757-347c-58f2" type="selectionEntry"/>
+    <entryLink id="1dec-e057-8cae-c9ae" name="Heretic Astartes Daemon Prince" hidden="false" collective="false" import="true" targetId="9bbd-a535-a4ef-9680" type="selectionEntry">
+      <costs>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="165"/>
+      </costs>
+    </entryLink>
+    <entryLink id="1087-e992-6b82-3b8" name="Heretic Astartes Daemon Prince with wings" hidden="false" collective="false" import="true" targetId="2a1d-2757-347c-58f2" type="selectionEntry">
+      <costs>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="180"/>
+      </costs>
+    </entryLink>
     <entryLink id="93c4-12f7-c81e-6f93" name="Fabius Bile" hidden="false" collective="false" import="true" targetId="cd9c-96e7-6dcb-bedf" type="selectionEntry"/>
-    <entryLink id="4725-7d2-e8e7-25ea" name="Cypher" hidden="false" collective="false" import="true" targetId="f399-fe33-375b-d1a2" type="selectionEntry"/>
+    <entryLink id="4725-7d2-e8e7-25ea" name="Cypher" hidden="false" collective="false" import="true" targetId="f399-fe33-375b-d1a2" type="selectionEntry">
+      <costs>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="90"/>
+      </costs>
+    </entryLink>
     <entryLink id="3ba8-9a15-694b-7bdd" name="Master of Possession" hidden="false" collective="false" import="true" targetId="287f-7d48-59cf-dc1e" type="selectionEntry"/>
     <entryLink id="abb7-f523-2b5a-b634" name="Chaos Lord" hidden="false" collective="false" import="true" targetId="e496-5a54-4cb2-4fc1" type="selectionEntry"/>
     <entryLink id="dcce-1991-7e0f-e98c" name="Chaos Lord in Terminator Armour" hidden="false" collective="false" import="true" targetId="b206-250d-84aa-fc42" type="selectionEntry"/>
@@ -130,19 +142,51 @@
     <entryLink id="81ed-a3bd-ed7d-8371" name="Exalted Champion" hidden="false" collective="false" import="true" targetId="f3d9-883e-6ca2-e3b" type="selectionEntry"/>
     <entryLink id="41a5-b3ea-bad2-8fbb" name="Dark Apostle" hidden="false" collective="false" import="true" targetId="d2b8-454a-d061-b592" type="selectionEntry"/>
     <entryLink id="9812-7717-4e8a-c269" name="Dark Commune" hidden="false" collective="false" import="true" targetId="1780-25b8-ce0b-898d" type="selectionEntry"/>
-    <entryLink id="db9f-5b64-ba4-dcd7" name="Legionaries" hidden="false" collective="false" import="true" targetId="615-e6bf-cfd2-9384" type="selectionEntry"/>
-    <entryLink id="7dda-eae9-2653-e091" name="Cultist Mob" hidden="false" collective="false" import="true" targetId="1267-78f1-7774-859" type="selectionEntry"/>
+    <entryLink id="db9f-5b64-ba4-dcd7" name="Legionaries" hidden="false" collective="false" import="true" targetId="615-e6bf-cfd2-9384" type="selectionEntry">
+      <costs>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="80"/>
+      </costs>
+    </entryLink>
+    <entryLink id="7dda-eae9-2653-e091" name="Cultist Mob" hidden="false" collective="false" import="true" targetId="1267-78f1-7774-859" type="selectionEntry">
+      <costs>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="50"/>
+      </costs>
+    </entryLink>
     <entryLink id="ec95-a3ef-cf96-89c1" name="Accursed Cultists" hidden="false" collective="false" import="true" targetId="23aa-b45a-6d5d-e92b" type="selectionEntry"/>
-    <entryLink id="cdc0-f214-d91d-a0fa" name="Chaos Terminator Squad" hidden="false" collective="false" import="true" targetId="203d-c50f-a438-4982" type="selectionEntry"/>
+    <entryLink id="cdc0-f214-d91d-a0fa" name="Chaos Terminator Squad" hidden="false" collective="false" import="true" targetId="203d-c50f-a438-4982" type="selectionEntry">
+      <costs>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="185"/>
+      </costs>
+    </entryLink>
     <entryLink id="3c72-d61f-c51-9116" name="Master of Executions" hidden="false" collective="false" import="true" targetId="da34-7071-8658-a453" type="selectionEntry"/>
-    <entryLink id="e472-f78e-1f6-b4f" name="Possessed" hidden="false" collective="false" import="true" targetId="cb1-5bcf-9e36-8136" type="selectionEntry"/>
+    <entryLink id="e472-f78e-1f6-b4f" name="Possessed" hidden="false" collective="false" import="true" targetId="cb1-5bcf-9e36-8136" type="selectionEntry">
+      <costs>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="130"/>
+      </costs>
+    </entryLink>
     <entryLink id="9204-3e94-d0f2-74d" name="Chosen" hidden="false" collective="false" import="true" targetId="4e85-615b-5d49-dfa4" type="selectionEntry"/>
     <entryLink id="25e-d95c-bda5-3f4f" name="Noise Marines" hidden="false" collective="false" import="true" targetId="1c45-9fd6-6303-a943" type="selectionEntry"/>
-    <entryLink id="f8e7-72ea-b430-918a" name="Venomcrawler" hidden="false" collective="false" import="true" targetId="3e98-7689-8bf0-96e0" type="selectionEntry"/>
-    <entryLink id="90c7-ee07-eb33-7df4" name="Chaos Bikers" hidden="false" collective="false" import="true" targetId="7373-47b7-11a3-2b48" type="selectionEntry"/>
-    <entryLink id="a7f0-ce36-c2d5-4dc1" name="Raptors" hidden="false" collective="false" import="true" targetId="acb5-dbf2-e3a6-ad94" type="selectionEntry"/>
+    <entryLink id="f8e7-72ea-b430-918a" name="Venomcrawler" hidden="false" collective="false" import="true" targetId="3e98-7689-8bf0-96e0" type="selectionEntry">
+      <costs>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="110"/>
+      </costs>
+    </entryLink>
+    <entryLink id="90c7-ee07-eb33-7df4" name="Chaos Bikers" hidden="false" collective="false" import="true" targetId="7373-47b7-11a3-2b48" type="selectionEntry">
+      <costs>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="75"/>
+      </costs>
+    </entryLink>
+    <entryLink id="a7f0-ce36-c2d5-4dc1" name="Raptors" hidden="false" collective="false" import="true" targetId="acb5-dbf2-e3a6-ad94" type="selectionEntry">
+      <costs>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="85"/>
+      </costs>
+    </entryLink>
     <entryLink id="687c-e5c-da99-96d8" name="Warp Talons" hidden="false" collective="false" import="true" targetId="9f33-ff4a-d948-4636" type="selectionEntry"/>
-    <entryLink id="fafa-8442-d6ef-4788" name="Havocs" hidden="false" collective="false" import="true" targetId="946c-d784-c8be-f21" type="selectionEntry"/>
+    <entryLink id="fafa-8442-d6ef-4788" name="Havocs" hidden="false" collective="false" import="true" targetId="946c-d784-c8be-f21" type="selectionEntry">
+      <costs>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="120"/>
+      </costs>
+    </entryLink>
     <entryLink id="b5e5-b8cd-dc7c-5b2b" name="Obliterators" hidden="false" collective="false" import="true" targetId="2311-fa63-364-22a3" type="selectionEntry"/>
     <entryLink id="add-bf9a-723c-95ce" name="Noctilith Crown" hidden="false" collective="false" import="true" targetId="a3ab-ed12-fa70-2042" type="selectionEntry"/>
     <entryLink id="eba3-150e-fb19-2ad7" name="Vashtorr the Arkifane" hidden="false" collective="false" import="true" targetId="dcc0-b70c-9779-e6c9" type="selectionEntry"/>
@@ -152,11 +196,23 @@
     <entryLink id="6bc9-c38b-40fa-49de" name="Chaos Land Raider" hidden="false" collective="false" import="true" targetId="6de7-36d5-6015-7a51" type="selectionEntry"/>
     <entryLink id="bb34-d2c-2f8e-4c73" name="Chaos Predator Annihilator" hidden="false" collective="false" import="true" targetId="279e-62d4-bff1-141" type="selectionEntry"/>
     <entryLink id="390c-50ca-b035-6ef8" name="Chaos Predator Destructor" hidden="false" collective="false" import="true" targetId="3dfb-3b2a-94b-2fbe" type="selectionEntry"/>
-    <entryLink id="4f23-20ad-7b6a-ce4a" name="Chaos Vindicator" hidden="false" collective="false" import="true" targetId="e687-6d7a-bb28-dcaa" type="selectionEntry"/>
+    <entryLink id="4f23-20ad-7b6a-ce4a" name="Chaos Vindicator" hidden="false" collective="false" import="true" targetId="e687-6d7a-bb28-dcaa" type="selectionEntry">
+      <costs>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="175"/>
+      </costs>
+    </entryLink>
     <entryLink id="429b-856c-7cb8-f6a2" name="Defiler" hidden="false" collective="false" import="true" targetId="7a72-5eae-45ca-7e8f" type="selectionEntry"/>
     <entryLink id="cc76-2cd4-e612-d34f" name="Forgefiend" hidden="false" collective="false" import="true" targetId="45b-19f6-38d2-703f" type="selectionEntry"/>
-    <entryLink id="f8f7-4a6f-8bf2-50c0" name="Helbrute" hidden="false" collective="false" import="true" targetId="9ff2-45e0-fe97-65f8" type="selectionEntry"/>
-    <entryLink id="413f-75fa-a18a-4863" name="Maulerfiend" hidden="false" collective="false" import="true" targetId="d37d-7e8f-341b-c67c" type="selectionEntry"/>
+    <entryLink id="f8f7-4a6f-8bf2-50c0" name="Helbrute" hidden="false" collective="false" import="true" targetId="9ff2-45e0-fe97-65f8" type="selectionEntry">
+      <costs>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="130"/>
+      </costs>
+    </entryLink>
+    <entryLink id="413f-75fa-a18a-4863" name="Maulerfiend" hidden="false" collective="false" import="true" targetId="d37d-7e8f-341b-c67c" type="selectionEntry">
+      <costs>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="140"/>
+      </costs>
+    </entryLink>
     <entryLink id="bd1-b506-69be-d983" name="Chaos Rhino" hidden="false" collective="false" import="true" targetId="e981-27ae-112f-aa9a" type="selectionEntry"/>
     <entryLink id="bbe4-98a0-4512-2454" name="Khorne Lord of Skulls" hidden="false" collective="false" import="true" targetId="b27f-1c85-5e7f-4e7d" type="selectionEntry"/>
     <entryLink id="6d9c-5405-809c-696a" name="Chaos Spawn" hidden="false" collective="false" import="true" targetId="7263-70e5-b424-61eb" type="selectionEntry"/>
@@ -1240,7 +1296,7 @@ A unit can only embark within (or start the battle embarked within) a TRANSPORT 
         <entryLink id="242f-eb21-ba0b-3b57" name="Allegiance" hidden="false" collective="false" import="true" targetId="5581-5d38-90b8-f8cd" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="165"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="180"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2a1d-2757-347c-58f2" name="Heretic Astartes Daemon Prince with wings" publicationId="48fc-15aa-b307-9443" hidden="false" collective="false" import="true" type="model">
@@ -1387,7 +1443,7 @@ A unit can only embark within (or start the battle embarked within) a TRANSPORT 
         <entryLink id="4d65-d4ed-1a4-3a73" name="Allegiance" hidden="false" collective="false" import="true" targetId="5581-5d38-90b8-f8cd" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="180"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="195"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="cd9c-96e7-6dcb-bedf" name="Fabius Bile" hidden="false" collective="false" import="true" type="unit">
@@ -1745,7 +1801,7 @@ A unit can only embark within (or start the battle embarked within) a TRANSPORT 
         <entryLink id="80a0-7a84-dd3-5f54" name="Warlord" hidden="false" collective="false" import="true" targetId="1a34-f1cc-ec01-ca32" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="90"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="105"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="287f-7d48-59cf-dc1e" name="Master of Possession" hidden="false" collective="false" import="true" type="model">
@@ -4321,7 +4377,7 @@ You can attach this model to one of the above units even if one other CHARACTER 
         <entryLink id="ed78-7994-335a-e389" name="Chaos icon" hidden="false" collective="false" import="true" targetId="4ea1-c93a-fc5a-9977" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="80"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="90"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="96f5-8be7-2cd8-f84f" name="Boltgun" hidden="false" collective="false" import="true" type="upgrade">
@@ -4750,7 +4806,7 @@ You can attach this model to one of the above units even if one other CHARACTER 
         <entryLink id="9c6-93be-cec9-3cdb" name="Allegiance" hidden="false" collective="false" import="true" targetId="5581-5d38-90b8-f8cd" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="50"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="55"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="23aa-b45a-6d5d-e92b" name="Accursed Cultists" hidden="false" collective="false" import="true" type="unit">
@@ -5191,7 +5247,7 @@ You can attach this model to one of the above units even if one other CHARACTER 
         <entryLink id="19b1-1a0f-3909-33b7" name="Allegiance" hidden="false" collective="false" import="true" targetId="5581-5d38-90b8-f8cd" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="185"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="195"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8094-a17b-7550-a066" name="Accursed weapon" hidden="false" collective="true" import="true" type="upgrade">
@@ -5500,7 +5556,7 @@ You can attach this model to one of the above units even if one other CHARACTER 
         <entryLink id="663d-4d7d-cd00-bb90" name="Chaos icon" hidden="false" collective="false" import="true" targetId="4ea1-c93a-fc5a-9977" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="130"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="140"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4e85-615b-5d49-dfa4" name="Chosen" hidden="false" collective="false" import="true" type="unit">
@@ -6272,7 +6328,7 @@ You can attach this model to one of the above units even if one other CHARACTER 
         <entryLink id="bf7e-5454-7c68-b77a" name="Allegiance" hidden="false" collective="false" import="true" targetId="5581-5d38-90b8-f8cd" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="110"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="120"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7373-47b7-11a3-2b48" name="Chaos Bikers" hidden="false" collective="false" import="true" type="unit">
@@ -6676,7 +6732,7 @@ You can attach this model to one of the above units even if one other CHARACTER 
         <entryLink id="69bf-4fb8-f1a5-ceae" name="Chaos icon" hidden="false" collective="false" import="true" targetId="4ea1-c93a-fc5a-9977" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="75"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="85"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3854-44a6-5746-d602" name="Close combat weapon" hidden="false" collective="true" import="true" type="upgrade">
@@ -6960,7 +7016,7 @@ You can attach this model to one of the above units even if one other CHARACTER 
         <entryLink id="cb07-b287-c4ff-5d84" name="Allegiance" hidden="false" collective="false" import="true" targetId="5581-5d38-90b8-f8cd" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="85"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="90"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="44ae-a376-590b-6349" name="Astartes chainsword" hidden="false" collective="false" import="true" type="upgrade">
@@ -7390,7 +7446,7 @@ You can attach this model to one of the above units even if one other CHARACTER 
         <entryLink id="c67d-35f7-6498-9ab6" name="Allegiance" hidden="false" collective="false" import="true" targetId="5581-5d38-90b8-f8cd" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="120"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="135"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2311-fa63-364-22a3" name="Obliterators" hidden="false" collective="false" import="true" type="unit">
@@ -9223,7 +9279,7 @@ You can attach this model to one of the above units even if one other CHARACTER 
         <entryLink id="e8d2-8c52-b95c-b03f" name="Mark of Chaos" hidden="false" collective="false" import="true" targetId="5581-5d38-90b8-f8cd" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="175"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="190"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7a72-5eae-45ca-7e8f" name="Defiler" hidden="false" collective="false" import="true" type="model">
@@ -9907,7 +9963,7 @@ You can attach this model to one of the above units even if one other CHARACTER 
         <entryLink id="9648-e14f-10c-c502" name="Mark of Chaos" hidden="false" collective="false" import="true" targetId="5581-5d38-90b8-f8cd" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="130"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="140"/>
       </costs>
       <selectionEntries>
         <selectionEntry type="upgrade" import="true" name="Close combat weapon" hidden="false" id="da4f-e317-2582-a402">
@@ -10185,7 +10241,7 @@ You can attach this model to one of the above units even if one other CHARACTER 
         <entryLink id="f1bc-aa05-a412-1660" name="Mark of Chaos" hidden="false" collective="false" import="true" targetId="5581-5d38-90b8-f8cd" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="140"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="155"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="e981-27ae-112f-aa9a" name="Chaos Rhino" hidden="false" collective="false" import="true" type="model">


### PR DESCRIPTION
Update `Chaos - Chaos Space Marines.cat` per [latest Munitorum 1.8](https://www.warhammer-community.com/wp-content/uploads/2023/06/ZPIdnv258NWwFQ8p.pdf).