### PR TITLE
Removed warlord option for Sydonian Skratros

### DIFF
--- a/Imperium - Adeptus Mechanicus.cat
+++ b/Imperium - Adeptus Mechanicus.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="77b9-2f66-3f9b-5cf3" name="Imperium - Adeptus Mechanicus" revision="27" battleScribeVersion="2.03" library="false" gameSystemId="sys-352e-adc2-7639-d6a9" gameSystemRevision="1" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="77b9-2f66-3f9b-5cf3" name="Imperium - Adeptus Mechanicus" revision="28" battleScribeVersion="2.03" library="false" gameSystemId="sys-352e-adc2-7639-d6a9" gameSystemRevision="1" type="catalogue">
   <categoryEntries>
     <categoryEntry id="f826-1ad1-a542-2058" name="Archaeopter Fusilave" hidden="false"/>
     <categoryEntry id="37b3-cded-c814-6e63" name="Archaeopter Stratoraptor" hidden="false"/>
@@ -6344,7 +6344,6 @@ Bodyguard unit, and that Bodyguard unit’s Starting Strength is increased acco
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink import="true" name="Warlord" hidden="false" type="selectionEntry" id="93c6-3c9b-d99c-e627" targetId="0580-79ca-da98-77c3"/>
         <entryLink import="true" name="Enhancements" hidden="false" type="selectionEntryGroup" id="3f36-d8a5-86c1-42f5" targetId="65bb-2001-cac8-2761"/>
       </entryLinks>
     </selectionEntry>


### PR DESCRIPTION
https://github.com/BSData/wh40k-10e/issues/1264

Closing issue #1264 

Removed option for warlord to Sydonian Skratros

I'm unsure why so many changes were created in the XML