### PR TITLE
Changed Archeotech pistol to Mechanicus Pistol

### DIFF
--- a/Imperium - Adeptus Mechanicus.cat
+++ b/Imperium - Adeptus Mechanicus.cat
@@ -6141,7 +6141,7 @@ Bodyguard unit, and that Bodyguard unit’s Starting Strength is increased acco
         <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="fe8b-2f1d-9a48-faa7"/>
       </constraints>
       <profiles>
-        <profile id="43ca-9255-d4f5-3962" name="Mechanicus Pistol" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+        <profile id="43ca-9255-d4f5-3962" name="Mechanicus pistol" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
           <characteristics>
             <characteristic name="Range" typeId="9896-9419-16a1-92fc">12&quot;</characteristic>
             <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
@@ -6256,25 +6256,6 @@ Bodyguard unit, and that Bodyguard unit’s Starting Strength is increased acco
             </profile>
           </profiles>
         </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Mechanicus Pistol" hidden="false" id="b292-c132-cfa6-f6c3">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="5d3-c6e5-b606-31d6"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="82fe-dfee-6366-265d"/>
-          </constraints>
-          <profiles>
-            <profile name="Mechanicus Pistol" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="f1b1-3342-76d4-1f18">
-              <characteristics>
-                <characteristic name="Range" typeId="9896-9419-16a1-92fc">12&quot;</characteristic>
-                <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
-                <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                <characteristic name="S" typeId="2229-f494-25db-c5d3">6</characteristic>
-                <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
-                <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Devastating Wounds, Pistol</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-        </selectionEntry>
       </selectionEntries>
       <infoLinks>
         <infoLink name="Doctrina Imperatives" hidden="false" type="rule" id="cf6c-4e23-e907-9a2a" targetId="7a21-a958-e47d-5c0d"/>
@@ -6329,6 +6310,7 @@ Bodyguard unit, and that Bodyguard unit’s Starting Strength is increased acco
       </selectionEntryGroups>
       <entryLinks>
         <entryLink import="true" name="Enhancements" hidden="false" type="selectionEntryGroup" id="3f36-d8a5-86c1-42f5" targetId="65bb-2001-cac8-2761"/>
+        <entryLink import="true" name="Mechanicus pistol" hidden="false" id="966e-b790-a1c9-e3ef" type="selectionEntry" targetId="2b1f-798d-9bca-4ad9"/>
       </entryLinks>
     </selectionEntry>
     <selectionEntry id="d99a-6563-8c08-23c" name="Sydonian Dragoons (Radium jezzail)" hidden="false" collective="false" import="true" type="unit">
@@ -6712,13 +6694,6 @@ Bodyguard unit, and that Bodyguard unit’s Starting Strength is increased acco
             <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
             <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Devastating Wounds, Pistol</characteristic>
           </characteristics>
-          <modifiers>
-            <modifier type="set" value="3+" field="94d-8a98-cf90-183e">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="9cfd-1c32-585f-7d5c" shared="true" id="7f03-f5ee-1230-4906"/>
-              </conditions>
-            </modifier>
-          </modifiers>
         </profile>
       </profiles>
       <infoLinks>

--- a/Imperium - Adeptus Mechanicus.cat
+++ b/Imperium - Adeptus Mechanicus.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="77b9-2f66-3f9b-5cf3" name="Imperium - Adeptus Mechanicus" revision="28" battleScribeVersion="2.03" library="false" gameSystemId="sys-352e-adc2-7639-d6a9" gameSystemRevision="1" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="77b9-2f66-3f9b-5cf3" name="Imperium - Adeptus Mechanicus" revision="30" battleScribeVersion="2.03" library="false" gameSystemId="sys-352e-adc2-7639-d6a9" gameSystemRevision="1" type="catalogue">
   <categoryEntries>
     <categoryEntry id="f826-1ad1-a542-2058" name="Archaeopter Fusilave" hidden="false"/>
     <categoryEntry id="37b3-cded-c814-6e63" name="Archaeopter Stratoraptor" hidden="false"/>
@@ -2053,7 +2053,7 @@ In either case, if it does, until the end of the turn, this unit is not eligible
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
-            <entryLink import="true" name="Archeotech pistol" hidden="false" type="selectionEntry" id="dcf2-b1e1-97e7-2b9a" targetId="2b1f-798d-9bca-4ad9">
+            <entryLink import="true" name="Mechanicus pistol" hidden="false" type="selectionEntry" id="dcf2-b1e1-97e7-2b9a" targetId="2b1f-798d-9bca-4ad9">
               <constraints>
                 <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="e680-6878-b8c7-73aa"/>
               </constraints>
@@ -2265,29 +2265,6 @@ In either case, if it does, until the end of the turn, this unit is not eligible
                 <infoLink name="Extra Attacks" hidden="false" type="rule" id="4b6e-38a8-9452-c3f7" targetId="115b-79dc-f723-d761"/>
               </infoLinks>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Phosphor blast pistol" hidden="false" id="45c2-eb7a-1ef6-a6b0">
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="5dfc-1b3b-776d-87f2-min"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5dfc-1b3b-776d-87f2-max"/>
-              </constraints>
-              <profiles>
-                <profile id="55f4-366f-a537-c296" name="Phosphor blast pistol" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
-                  <characteristics>
-                    <characteristic name="Range" typeId="9896-9419-16a1-92fc">12&quot;</characteristic>
-                    <characteristic name="A" typeId="3bb-c35f-f54-fb08">D3</characteristic>
-                    <characteristic name="BS" typeId="94d-8a98-cf90-183e">4+</characteristic>
-                    <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
-                    <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Ignores Cover, Blast</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <infoLinks>
-                <infoLink name="Blast" hidden="false" type="rule" id="6605-b819-691b-3b92" targetId="6c1f-1cf7-ff25-c99e"/>
-                <infoLink name="Ignores Cover" hidden="false" type="rule" id="75b7-7ebe-f08e-4014" targetId="4640-43e7-30b-215a"/>
-              </infoLinks>
-            </selectionEntry>
             <selectionEntry type="upgrade" import="true" name="Clawed limbs" hidden="false" id="7daf-7fdf-9ddc-3e65" collective="false">
               <constraints>
                 <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="c3d2-702b-b17-f194-min"/>
@@ -2332,6 +2309,13 @@ In either case, if it does, until the end of the turn, this unit is not eligible
               </infoLinks>
             </selectionEntry>
           </selectionEntries>
+          <entryLinks>
+            <entryLink import="true" name="Mechanicus pistol" hidden="false" id="aad4-a5be-e1b8-9c57" type="selectionEntry" targetId="2b1f-798d-9bca-4ad9">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="2cda-a35d-5b47-86e6"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -3030,7 +3014,7 @@ In either case, if it does, until the end of the turn, this unit is not eligible
           </constraints>
         </entryLink>
         <entryLink id="14f8-77fd-ef8f-c7ca" name="Enhancements" hidden="false" collective="false" import="true" targetId="65bb-2001-cac8-2761" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Archeotech pistol" hidden="false" type="selectionEntry" id="7a3d-dcaf-9983-30dc" targetId="2b1f-798d-9bca-4ad9">
+        <entryLink import="true" name="Mechanicus pistol" hidden="false" type="selectionEntry" id="7a3d-dcaf-9983-30dc" targetId="2b1f-798d-9bca-4ad9">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b06-134b-ae0f-fac4"/>
           </constraints>
@@ -3133,7 +3117,7 @@ In either case, if it does, until the end of the turn, this unit is not eligible
                 </selectionEntry>
               </selectionEntries>
               <entryLinks>
-                <entryLink import="true" name="Archeotech pistol" hidden="false" type="selectionEntry" id="81fb-ddc2-edef-4aab" targetId="2b1f-798d-9bca-4ad9"/>
+                <entryLink import="true" name="Mechanicus pistol" hidden="false" type="selectionEntry" id="81fb-ddc2-edef-4aab" targetId="2b1f-798d-9bca-4ad9"/>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup name="Melee Weapon" hidden="false" id="537-47d-fe18-86cd">
@@ -3533,7 +3517,7 @@ as the target of a Stratagem, roll one D6: on a 5+, you gain 1CP.</characteristi
                 </selectionEntry>
               </selectionEntries>
               <entryLinks>
-                <entryLink import="true" name="Archeotech pistol" hidden="false" type="selectionEntry" id="915b-b27-8b9a-8603" targetId="2b1f-798d-9bca-4ad9"/>
+                <entryLink import="true" name="Mechanicus pistol" hidden="false" type="selectionEntry" id="915b-b27-8b9a-8603" targetId="2b1f-798d-9bca-4ad9"/>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
@@ -4475,7 +4459,7 @@ as the target of a Stratagem, roll one D6: on a 5+, you gain 1CP.</characteristi
           </constraints>
         </entryLink>
         <entryLink id="5f02-f928-746f-8af4" name="Enhancements" hidden="false" collective="false" import="true" targetId="65bb-2001-cac8-2761" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Archeotech pistol" hidden="false" type="selectionEntry" id="7ae8-9a5b-2f90-2c78" targetId="2b1f-798d-9bca-4ad9">
+        <entryLink import="true" name="Mechanicus pistol" hidden="false" type="selectionEntry" id="7ae8-9a5b-2f90-2c78" targetId="2b1f-798d-9bca-4ad9">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="bd17-1cc0-3521-9c5f"/>
           </constraints>
@@ -4717,7 +4701,7 @@ as the target of a Stratagem, roll one D6: on a 5+, you gain 1CP.</characteristi
           </constraints>
         </entryLink>
         <entryLink id="318b-87d8-48f4-8665" name="Enhancements" hidden="false" collective="false" import="true" targetId="65bb-2001-cac8-2761" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Archeotech pistol" hidden="false" type="selectionEntry" id="fd76-d241-96fb-7463" targetId="2b1f-798d-9bca-4ad9">
+        <entryLink import="true" name="Mechanicus pistol" hidden="false" type="selectionEntry" id="fd76-d241-96fb-7463" targetId="2b1f-798d-9bca-4ad9">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="bc8c-71b5-2393-6dbf"/>
           </constraints>
@@ -4801,7 +4785,7 @@ You must attach this model to a Kastelan Robots unit, even if one or more other 
           </constraints>
         </entryLink>
         <entryLink id="f2db-d9ec-b48a-5c56" name="Enhancements" hidden="false" collective="false" import="true" targetId="65bb-2001-cac8-2761" type="selectionEntryGroup"/>
-        <entryLink import="true" name="Archeotech pistol" hidden="false" type="selectionEntry" id="44cd-1441-b29d-85d0" targetId="2b1f-798d-9bca-4ad9">
+        <entryLink import="true" name="Mechanicus pistol" hidden="false" type="selectionEntry" id="44cd-1441-b29d-85d0" targetId="2b1f-798d-9bca-4ad9">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="48c7-305-f78e-ea8c"/>
           </constraints>
@@ -4962,7 +4946,7 @@ You must attach this model to a Kastelan Robots unit, even if one or more other 
                 </selectionEntry>
               </selectionEntries>
               <entryLinks>
-                <entryLink import="true" name="Archeotech pistol" hidden="false" type="selectionEntry" id="7ad8-5428-b5-cd9b" targetId="2b1f-798d-9bca-4ad9"/>
+                <entryLink import="true" name="Archeotech pistol" hidden="false" type="selectionEntry" id="7ad8-5428-b5-cd9b" targetId="bf8f-f66e-c3fa-a46d"/>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
@@ -5289,7 +5273,7 @@ You must attach this model to a Kastelan Robots unit, even if one or more other 
                 </selectionEntry>
               </selectionEntries>
               <entryLinks>
-                <entryLink import="true" name="Archeotech pistol" hidden="false" type="selectionEntry" id="ab8d-b5c1-13c2-8bda" targetId="2b1f-798d-9bca-4ad9"/>
+                <entryLink import="true" name="Archeotech pistol" hidden="false" type="selectionEntry" id="ab8d-b5c1-13c2-8bda" targetId="bf8f-f66e-c3fa-a46d"/>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
@@ -6152,12 +6136,12 @@ Bodyguard unit, and that Bodyguard unit’s Starting Strength is increased acco
         <infoLink name="Hazardous" hidden="false" type="rule" id="c25f-daaf-2f5a-720c" targetId="8367-374c-f87-c627"/>
       </infoLinks>
     </selectionEntry>
-    <selectionEntry type="upgrade" import="true" name="Archeotech pistol" hidden="false" id="2b1f-798d-9bca-4ad9">
+    <selectionEntry type="upgrade" import="true" name="Mechanicus pistol" hidden="false" id="2b1f-798d-9bca-4ad9">
       <constraints>
         <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="fe8b-2f1d-9a48-faa7"/>
       </constraints>
       <profiles>
-        <profile id="43ca-9255-d4f5-3962" name="Archeotech pistol" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+        <profile id="43ca-9255-d4f5-3962" name="Mechanicus Pistol" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
           <characteristics>
             <characteristic name="Range" typeId="9896-9419-16a1-92fc">12&quot;</characteristic>
             <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
@@ -6712,6 +6696,35 @@ Bodyguard unit, and that Bodyguard unit’s Starting Strength is increased acco
           </characteristics>
         </profile>
       </profiles>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Archeotech pistol" hidden="false" id="bf8f-f66e-c3fa-a46d">
+      <constraints>
+        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="63a8-f8c6-1e49-48f4"/>
+      </constraints>
+      <profiles>
+        <profile id="8a3b-6e6b-8434-b486" name="Archeotech pistol" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
+          <characteristics>
+            <characteristic name="Range" typeId="9896-9419-16a1-92fc">12&quot;</characteristic>
+            <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
+            <characteristic name="BS" typeId="94d-8a98-cf90-183e">4+</characteristic>
+            <characteristic name="S" typeId="2229-f494-25db-c5d3">6</characteristic>
+            <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
+            <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
+            <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Devastating Wounds, Pistol</characteristic>
+          </characteristics>
+          <modifiers>
+            <modifier type="set" value="3+" field="94d-8a98-cf90-183e">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="9cfd-1c32-585f-7d5c" shared="true" id="7f03-f5ee-1230-4906"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink name="Devastating Wounds" hidden="false" type="rule" id="cc67-53b6-9c74-b181" targetId="be1e-ac8e-1e2c-3528"/>
+        <infoLink name="Pistol" hidden="false" type="rule" id="9170-907c-d0ef-225d" targetId="8bf7-8812-923d-29e4"/>
+      </infoLinks>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>


### PR DESCRIPTION
Changed Archeotech pistol to Mechanicus Pistol
Created Archeotech pistol again for Secutarii
Fixed pistol for Serberys Sulphurhounds Alpha from Phosphor blast pisto lto Mechanicus pistol

This solves #1297 

I set revision to 30 to not have problems with the other PR where I set revision to 29.
If both PR should have revision 29, let me know and I can change it.