### PR TITLE
Update Imperium - Astra Militarum - Library.cat

### DIFF
--- a/Imperium - Astra Militarum - Library.cat
+++ b/Imperium - Astra Militarum - Library.cat
@@ -2631,6 +2631,18 @@
           </selectionEntries>
         </selectionEntry>
         <selectionEntry type="model" import="true" name="Tanith Ghost w/ Bragg&apos;s autocannon" hidden="false" id="5b43-2a5d-939c-d738">
+          <profiles>
+            <profile name="Tanith Ghost" typeId="c547-1836-d8a-ff4f" typeName="Unit" hidden="false" id="5151-a7a3-af13-2391">
+              <characteristics>
+                <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">6&quot;</characteristic>
+                <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">3</characteristic>
+                <characteristic name="SV" typeId="450-a17e-9d5e-29da">5+</characteristic>
+                <characteristic name="W" typeId="750a-a2ec-90d3-21fe">2</characteristic>
+                <characteristic name="LD" typeId="58d2-b879-49c7-43bc">7+</characteristic>
+                <characteristic name="OC" typeId="bef7-942a-1a23-59f8">1</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="398d-58ee-dda2-33b4"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="56b8-4fab-9349-bc43"/>


### PR DESCRIPTION
## add missing characteristics to "Tanith Ghost w/ Bragg&apos;s autocannon"

I don't know that this is the correct thing to do, but I'm guessing that yellowscribe is giving every tanith ghost 3/3W instead of 2/2W for all but Ibram Gaunt because of a missing characteristics block.

Please take a look :pray: