### PR TITLE
Tyranids MFM, Dataslate  & Errata

### DIFF
--- a/Tyranids.cat
+++ b/Tyranids.cat
@@ -437,8 +437,7 @@
       <description>If your Army Faction is TYRANIDS, while a TYRANIDS unit from your army is within 6&quot; of one or more friendly SYNAPSE  models, that TYRANIDS unit is said to be within Synapse Range of that model and of your army. While a Tyranids unit from your army is within Synapse Range of your army:
 
 ■ Each time that unit takes a Battle-shock test, take that test on 3D6 instead of 2D6.
-■ Each time a model in that unit makes a melee attack, add 1 to the Strength characteristic of that attack.
-</description>
+■ Each time a model in that unit makes a melee attack, add 1 to the Strength characteristic of that attack.</description>
     </rule>
   </rules>
   <sharedSelectionEntries>
@@ -3613,9 +3612,6 @@
               </constraints>
             </selectionEntryGroup>
           </selectionEntryGroups>
-          <costs>
-            <cost name="pts" typeId="51b2-306e-1021-d207" value="25"/>
-          </costs>
           <modifiers>
             <modifier type="set" value="3" field="787-2337-ccc2-c523">
               <conditions>
@@ -3681,6 +3677,16 @@
         <modifier type="set" value="40" field="51b2-306e-1021-d207">
           <conditions>
             <condition type="equalTo" value="2" field="selections" scope="1de2-b57b-aa0a-1f0d" childId="model" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" value="25" field="51b2-306e-1021-d207">
+          <conditions>
+            <condition type="equalTo" value="1" field="selections" scope="1de2-b57b-aa0a-1f0d" childId="model" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" value="50" field="51b2-306e-1021-d207">
+          <conditions>
+            <condition type="equalTo" value="3" field="selections" scope="1de2-b57b-aa0a-1f0d" childId="model" shared="true" includeChildSelections="true"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -7112,8 +7118,7 @@ Each time a Tyranids model with this Hyper-adaptation makes an attack that targe
           <profiles>
             <profile name="Enraged Behemoths" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="2bb9-e5dd-1201-30a4">
               <characteristics>
-                <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time a TYRANIDS MONSTER model from your army makes an attack, add 1 to the Hit roll if that model’s unit is below its Starting Strength, and add 1 to the Wound roll as well if that model’s unit is Below Half-strength. In addition, while a TYRANIDS MONSTER unit from your army (excluding Battle-shocked units) is at its Starting Strength, add 2 to the Objective Control characteristic of models in that unit.
-</characteristic>
+                <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time a TYRANIDS MONSTER model from your army makes an attack, add 1 to the Hit roll if that model’s unit is below its Starting Strength, and add 1 to the Wound roll as well if that model’s unit is Below Half-strength. In addition, while a TYRANIDS MONSTER unit from your army (excluding Battle-shocked units) is at its Starting Strength, add 2 to the Objective Control characteristic of models in that unit.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -7934,8 +7939,7 @@ Each time a Tyranids model with this Hyper-adaptation makes an attack that targe
   </catalogueLinks>
   <sharedRules>
     <rule id="395b-a159-b293-27aa" name="Shadow in the Warp" hidden="false">
-      <description>If your Army Faction is TYRANIDS, once per battle, in either player’s Command phase, if one or more units from your army with this ability are on the battlefield, you can unleash the Shadow in the Warp. When you do, each enemy unit on the battlefield must take a Battle-shock test. Each time an enemy unit takes such a Battle-shock test, if it is within 6&quot; of one or more Synapse units from your army, subtract 1 from that test.
-</description>
+      <description>If your Army Faction is TYRANIDS, once per battle, in either player’s Command phase, if one or more units from your army with this ability are on the battlefield, you can unleash the Shadow in the Warp. When you do, each enemy unit on the battlefield must take a Battle-shock test. Each time an enemy unit takes such a Battle-shock test, if it is within 6&quot; of one or more Synapse units from your army, subtract 1 from that test.</description>
     </rule>
   </sharedRules>
 </catalogue>

--- a/Tyranids.cat
+++ b/Tyranids.cat
@@ -434,7 +434,11 @@
   </entryLinks>
   <rules>
     <rule id="86aa-437f-260b-5cad" name="Synapse" hidden="false">
-      <description>If your Army Faction is TYRANIDS, while a TYRANIDS unit from your army is within 6&quot; of one or more SYNAPSE models from your army, that unit is said to be within Synapse Range of your army. Each time a TYRANIDS unit from your army takes a Battle-shock test, if it is within Synapse Range of your army, take that test on 3D6 instead of 2D6.</description>
+      <description>If your Army Faction is TYRANIDS, while a TYRANIDS unit from your army is within 6&quot; of one or more friendly SYNAPSE  models, that TYRANIDS unit is said to be within Synapse Range of that model and of your army. While a Tyranids unit from your army is within Synapse Range of your army:
+
+■ Each time that unit takes a Battle-shock test, take that test on 3D6 instead of 2D6.
+■ Each time a model in that unit makes a melee attack, add 1 to the Strength characteristic of that attack.
+</description>
     </rule>
   </rules>
   <sharedSelectionEntries>
@@ -666,7 +670,7 @@
         </profile>
         <profile name="Onslaught (Aura, Psychic)" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="d038-2f3d-1c4a-a15">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While a friendly TYRANIDS unit is within 6&quot; of this model, ranged weapons equipped by models in that unit have the [ASSAULT] ability.</characteristic>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While a friendly TYRANIDS unit is within 6&quot; of this model, ranged weapons equipped by models in that unit have the [ASSAULT] and [LETHAL HITS] abilities.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -1068,6 +1072,7 @@
         </infoLink>
         <infoLink id="71f8-7352-fa30-366c" name="Invulnerable Save" hidden="false" targetId="a2fa-ebfd-7b32-9a75" type="profile"/>
         <infoLink name="Synapse" hidden="false" type="rule" id="c52f-a31e-35e3-d878" targetId="86aa-437f-260b-5cad"/>
+        <infoLink name="Shadow in the Warp" id="b52f-37b8-c833-cbea" hidden="false" type="rule" targetId="395b-a159-b293-27aa"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="f5d8-46d3-9bd5-c53f" name="Infantry" hidden="false" targetId="cf47-a0d7-7207-29dc" primary="false"/>
@@ -1077,6 +1082,7 @@
         <categoryLink id="dd73-9705-9e92-58f4" name="Faction: Tyranids" hidden="false" targetId="d1d8-6ae0-1be7-e9e" primary="false"/>
         <categoryLink id="dfcf-8237-2843-d1f7" name="Great Devourer" hidden="false" targetId="7850-cc5a-c191-b80d" primary="false"/>
         <categoryLink targetId="5ff0-d52d-e2b8-9de" id="303e-eb75-57c2-25a3" primary="false" name="Vanguard Invader"/>
+        <categoryLink targetId="4129-a453-686a-d38a" id="2aad-9562-a42b-26bb" primary="false" name="Synapse"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="9aef-ce2-edd5-bfb4" name="Broodlord Claws and Talons" hidden="false" collective="false" import="true" type="upgrade">
@@ -2436,7 +2442,8 @@
               <characteristics>
                 <characteristic name="Description" typeId="9b8f-694b-e5e-b573">This model can be attached to the following units:
 - NEUROGAUNT
-- TYRANT GUARD</characteristic>
+- TYRANT GUARD
+- ZOANTHROPES</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -3687,6 +3694,7 @@
         <categoryLink targetId="cf47-a0d7-7207-29dc" id="b4bb-15ac-b4d0-e3fa" primary="false" name="Infantry"/>
         <categoryLink targetId="d1d8-6ae0-1be7-e9e" id="3c92-5469-8c59-9bce" primary="false" name="Faction: Tyranids"/>
         <categoryLink targetId="5ff0-d52d-e2b8-9de" id="1e37-ab13-5b2b-723b" primary="false" name="Vanguard Invader"/>
+        <categoryLink targetId="4129-a453-686a-d38a" id="4385-be5d-d940-b462" primary="false" name="Synapse"/>
       </categoryLinks>
       <profiles>
         <profile name="Parasitic Infection" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="e63a-3205-566f-57d8">
@@ -3766,6 +3774,7 @@
         <infoLink name="Lone Operative" hidden="false" type="rule" id="9896-94da-baab-62f5" targetId="a8a0-8fe7-898-e0f3"/>
         <infoLink name="Stealth" hidden="false" type="rule" id="49f-799d-a6ab-8d36" targetId="bec5-4288-34a6-ccfa"/>
         <infoLink name="Synapse" hidden="false" type="rule" id="5d13-15eb-7d5c-2962" targetId="86aa-437f-260b-5cad"/>
+        <infoLink name="Shadow in the Warp" id="e592-f7b4-fc49-bd73" hidden="false" type="rule" targetId="395b-a159-b293-27aa"/>
       </infoLinks>
       <entryLinks>
         <entryLink import="true" name="Enhancements" hidden="false" type="selectionEntryGroup" id="268b-1435-81be-2aaa" targetId="fa5b-f646-b960-a8d3"/>
@@ -3781,6 +3790,7 @@
         <categoryLink targetId="9693-cf84-fe69-37a9" id="d8aa-4780-31e1-ab53" primary="true" name="Monster"/>
         <categoryLink targetId="7850-cc5a-c191-b80d" id="53f2-d491-ba54-2af0" primary="false" name="Great Devourer"/>
         <categoryLink targetId="d1d8-6ae0-1be7-e9e" id="88e-e466-4c10-e9e4" primary="false" name="Faction: Tyranids"/>
+        <categoryLink targetId="5ff0-d52d-e2b8-9de" id="3c73-177b-31be-492a" primary="false" name="Vanguard Invader"/>
       </categoryLinks>
       <infoLinks>
         <infoLink name="Damaged: 1-5 Wounds Remaining" hidden="false" type="profile" id="7d08-be71-f23c-d1be" targetId="384f-e5ff-31a2-1295"/>
@@ -3866,6 +3876,7 @@
         <categoryLink targetId="9693-cf84-fe69-37a9" id="a829-323-20c4-473" primary="true" name="Monster"/>
         <categoryLink targetId="7850-cc5a-c191-b80d" id="7b79-1069-5ae-eee" primary="false" name="Great Devourer"/>
         <categoryLink targetId="d1d8-6ae0-1be7-e9e" id="6c34-b85f-7172-37e5" primary="false" name="Faction: Tyranids"/>
+        <categoryLink targetId="5ff0-d52d-e2b8-9de" id="9af4-f9f5-867e-1b54" primary="false" name="Vanguard Invader"/>
       </categoryLinks>
       <profiles>
         <profile name="Subterranean Tunnels" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="ca9b-8e0-47fa-32ed">
@@ -4071,7 +4082,7 @@
                 <characteristic name="Range" typeId="9896-9419-16a1-92fc">36&quot;</characteristic>
                 <characteristic name="A" typeId="3bb-c35f-f54-fb08">D6+3</characteristic>
                 <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                <characteristic name="S" typeId="2229-f494-25db-c5d3">8</characteristic>
+                <characteristic name="S" typeId="2229-f494-25db-c5d3">9</characteristic>
                 <characteristic name="AP" typeId="9ead-8a10-520-de15">-3</characteristic>
                 <characteristic name="D" typeId="a354-c1c8-a745-f9e3">3</characteristic>
                 <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Blast, Heavy</characteristic>
@@ -4819,7 +4830,7 @@
                     <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
                     <characteristic name="S" typeId="2229-f494-25db-c5d3">18</characteristic>
                     <characteristic name="AP" typeId="9ead-8a10-520-de15">-4</characteristic>
-                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">2D6</characteristic>
+                    <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6+6</characteristic>
                     <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Heavy</characteristic>
                   </characteristics>
                 </profile>
@@ -6033,6 +6044,7 @@
         <categoryLink targetId="cf47-a0d7-7207-29dc" id="e682-eda-bfba-9add" primary="true" name="Infantry"/>
         <categoryLink targetId="7850-cc5a-c191-b80d" id="dbc9-44b2-259b-64d8" primary="false" name="Great Devourer"/>
         <categoryLink targetId="1785-c8af-b343-a1a6" id="251-3fa1-5b44-9377" primary="false" name="Raveners"/>
+        <categoryLink targetId="5ff0-d52d-e2b8-9de" id="bce4-d53c-fe2d-a250" primary="false" name="Vanguard Invader"/>
       </categoryLinks>
       <costs>
         <cost name="pts" typeId="51b2-306e-1021-d207" value="75"/>
@@ -6500,6 +6512,7 @@
         <categoryLink targetId="de12-e6b6-16c1-47b0" id="6e20-4803-c60e-d4b5" primary="false" name="Neurolictor"/>
         <categoryLink targetId="5ff0-d52d-e2b8-9de" id="d1cf-b4b6-2a74-ebe2" primary="false" name="Vanguard Invader"/>
         <categoryLink targetId="d1d8-6ae0-1be7-e9e" id="5444-14e5-924a-a067" primary="false" name="Faction: Tyranids"/>
+        <categoryLink targetId="4129-a453-686a-d38a" id="dcdb-634f-47f4-8a5d" primary="false" name="Synapse"/>
       </categoryLinks>
       <constraints>
         <constraint type="max" value="3" field="selections" scope="roster" shared="true" id="6a75-a5f5-1da7-a85c" includeChildSelections="false" includeChildForces="true"/>
@@ -7099,7 +7112,8 @@ Each time a Tyranids model with this Hyper-adaptation makes an attack that targe
           <profiles>
             <profile name="Enraged Behemoths" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="2bb9-e5dd-1201-30a4">
               <characteristics>
-                <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time a TYRANIDS MONSTER model from your army makes an attack, add 1 to the Hit roll if that model&apos;s unit is below its Starting Strength, and add 1 to the Wound roll as well if that model&apos;s unit is Below Half-strength</characteristic>
+                <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time a TYRANIDS MONSTER model from your army makes an attack, add 1 to the Hit roll if that model’s unit is below its Starting Strength, and add 1 to the Wound roll as well if that model’s unit is Below Half-strength. In addition, while a TYRANIDS MONSTER unit from your army (excluding Battle-shocked units) is at its Starting Strength, add 2 to the Objective Control characteristic of models in that unit.
+</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -7774,7 +7788,7 @@ Each time a Tyranids model with this Hyper-adaptation makes an attack that targe
               <profiles>
                 <profile id="a260-81c2-7cda-a6ae" name="Neuronode" hidden="false" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities">
                   <characteristics>
-                    <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Tyranids model only. After both players have deployed their armies and determined who has first turn, you can select up to three VANGUARD INVADER units from your army and redeploy all of those units. When doing s, any of those units can be placed into Strategic Reserves, regardless of how many units are already in Strategic Reserves.</characteristic>
+                    <characteristic name="Description" typeId="9b8f-694b-e5e-b573">TYRANIDS model only. After both players have deployed their armies, you can select up to three VANGUARD INVADER units from your army and redeploy all of those units. When doing so, any of those units can be placed into Strategic Reserves, regardless of how many units are already in Strategic Reserves.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -7920,7 +7934,8 @@ Each time a Tyranids model with this Hyper-adaptation makes an attack that targe
   </catalogueLinks>
   <sharedRules>
     <rule id="395b-a159-b293-27aa" name="Shadow in the Warp" hidden="false">
-      <description>If your Army Faction is TYRANIDS, once per battle, in either player’s Command phase, if one or more units from your army with this ability are on the battlefield, you can unleash the Shadow in the Warp. When you do, each enemy unit on the battlefield must take a Battle-shock test.</description>
+      <description>If your Army Faction is TYRANIDS, once per battle, in either player’s Command phase, if one or more units from your army with this ability are on the battlefield, you can unleash the Shadow in the Warp. When you do, each enemy unit on the battlefield must take a Battle-shock test. Each time an enemy unit takes such a Battle-shock test, if it is within 6&quot; of one or more Synapse units from your army, subtract 1 from that test.
+</description>
     </rule>
   </sharedRules>
 </catalogue>

--- a/Tyranids.cat
+++ b/Tyranids.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="b984-7317-81cc-20f" name="Xenos - Tyranids" revision="51" battleScribeVersion="2.03" library="false" gameSystemId="sys-352e-adc2-7639-d6a9" gameSystemRevision="1" type="catalogue" authorName="FitalShell" authorContact="fitalshell">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="b984-7317-81cc-20f" name="Xenos - Tyranids" revision="52" battleScribeVersion="2.03" library="false" gameSystemId="sys-352e-adc2-7639-d6a9" gameSystemRevision="1" type="catalogue" authorName="FitalShell" authorContact="fitalshell">
   <categoryEntries>
     <categoryEntry name="Synapse" hidden="false" id="4129-a453-686a-d38a"/>
     <categoryEntry id="4f10-fe01-4b80-8d6b" name="Winged Hive Tyrant" hidden="false"/>
@@ -905,7 +905,7 @@
         <entryLink id="c8f2-2473-63a9-2a2" name="Warlord" hidden="false" collective="false" import="true" targetId="ceab-62d9-31bf-7c61" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="190"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="175"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="13f7-1a3-eff-7393" name="The Swarmlord" hidden="false" collective="false" import="true" type="model">
@@ -3607,7 +3607,7 @@
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>
-            <cost name="pts" typeId="51b2-306e-1021-d207" value="20"/>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="25"/>
           </costs>
           <modifiers>
             <modifier type="set" value="3" field="787-2337-ccc2-c523">
@@ -3670,6 +3670,13 @@
           </modifiers>
         </modifierGroup>
       </modifierGroups>
+      <modifiers>
+        <modifier type="set" value="40" field="51b2-306e-1021-d207">
+          <conditions>
+            <condition type="equalTo" value="2" field="selections" scope="1de2-b57b-aa0a-1f0d" childId="model" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
     </selectionEntry>
     <selectionEntry type="model" import="true" name="Parasite of Mortrex" hidden="false" id="d213-efd8-a2b4-42d2">
       <categoryLinks>
@@ -3940,7 +3947,7 @@
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Mucolid Spore" hidden="false" id="65ba-c344-5752-c9c8">
           <costs>
-            <cost name="pts" typeId="51b2-306e-1021-d207" value="50"/>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="30"/>
           </costs>
           <profiles>
             <profile name="Mucolid Spore" typeId="c547-1836-d8a-ff4f" typeName="Unit" hidden="false" id="34bf-a591-5c55-361e">
@@ -4126,7 +4133,7 @@
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Biovore" hidden="false" id="dd57-9c1f-d425-6711">
           <costs>
-            <cost name="pts" typeId="51b2-306e-1021-d207" value="75"/>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="50"/>
           </costs>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="a9fc-d3c7-dab6-6975" includeChildSelections="true"/>
@@ -6498,7 +6505,7 @@
         <constraint type="max" value="3" field="selections" scope="roster" shared="true" id="6a75-a5f5-1da7-a85c" includeChildSelections="false" includeChildForces="true"/>
       </constraints>
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="80"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="90"/>
       </costs>
       <infoLinks>
         <infoLink name="Shadow in the Warp" hidden="false" type="rule" id="500d-6298-c46d-d8c1" targetId="395b-a159-b293-27aa"/>


### PR DESCRIPTION
- update points according to MFM
- add modifier for Ripper Swarms (non-linear model cost)
- Dataslate and errata changes

Please verify the Ripper Swarms are correct since the cost no longer increases equally from 1 to 2 to 3 models.

#1338
#1339
