### PR TITLE
Fix Transport Capacity Descriptions for Space Marine Vehicles

### DIFF
--- a/Imperium - Space Marines.cat
+++ b/Imperium - Space Marines.cat
@@ -90,7 +90,6 @@
     <categoryEntry id="551d-174d-e214-52d6" name="Land Raider Redeemer" hidden="false"/>
     <categoryEntry id="6f4f-95b8-5802-55b6" name="Repulsor" hidden="false"/>
     <categoryEntry id="cca9-5590-14a6-19e8" name="Repulsor Executioner" hidden="false"/>
-    <categoryEntry id="fcd4-51e2-7b33-44cc" name="Repulsor Executioner" hidden="false"/>
     <categoryEntry id="f8d9-fe3d-8e9f-4ec3" name="Rhino" hidden="false"/>
     <categoryEntry id="3b42-5c4f-374-6a77" name="Razorback" hidden="false"/>
     <categoryEntry id="7476-fb8e-bd5a-cfbe" name="Impulsor" hidden="false"/>
@@ -11812,7 +11811,7 @@ Normal move. If it does so, until the end of the turn, this unit is not eligible
         </profile>
         <profile name="Transport" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="e922-59ba-baa0-655c">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">This model has a transport capacity of 12 Adeptus Astartes Infantry models. Each Jump Pack, Wulfen, Gravis or Terminator model takes up the space of 2 models and each Centurion model takes up the space of 3 models.</characteristic>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">This model has a transport capacity of 14 Adeptus Astartes Infantry models. Each Jump Pack, Wulfen, Gravis or Terminator model takes up the space of 2 models and each Centurion model takes up the space of 3 models.</characteristic>
           </characteristics>
         </profile>
         <profile name="Emergency Combat Embarkation" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="be1c-1cd0-5306-55d7">
@@ -12258,7 +12257,7 @@ Normal move. If it does so, until the end of the turn, this unit is not eligible
         </profile>
         <profile name="Transport" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="51b9-1985-e818-cc43">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">This model has a transport capacity of 6 Tacticus or Phobos Infantry models. It cannot transport Jump Pack models.</characteristic>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">This model has a transport capacity of 7 Tacticus or Phobos Infantry models. It cannot transport Jump Pack models.</characteristic>
           </characteristics>
         </profile>
         <profile name="Assault Vehicle" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="aa73-4cca-5285-aa">


### PR DESCRIPTION
increase repulsor transport capacity description to reflect the new dataslate changes

increase impulsor transport capactiy description to reflect the new dataslate changes

remove duplicate repulsor executioner reference.

resolves #1355 
resolves #1348 