### PR TITLE
Add Death Cult Assassins as Legends unit

### DIFF
--- a/Imperium - Adepta Sororitas.cat
+++ b/Imperium - Adepta Sororitas.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="b39e-4401-8f3e-fdf7" name="Imperium - Adepta Sororitas" gameSystemId="sys-352e-adc2-7639-d6a9" gameSystemRevision="1" revision="31" battleScribeVersion="2.03" authorName="CrusherJoe" type="catalogue" authorContact="@CrusherJoe on Discord" authorUrl="Sometimes GitHub blows">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="b39e-4401-8f3e-fdf7" name="Imperium - Adepta Sororitas" gameSystemId="sys-352e-adc2-7639-d6a9" gameSystemRevision="1" revision="32" battleScribeVersion="2.03" authorName="CrusherJoe" type="catalogue" authorContact="@CrusherJoe on Discord" authorUrl="Sometimes GitHub blows">
   <categoryEntries>
     <categoryEntry name="Aestred Thurga and Agathae Dolan" hidden="false" id="c8ba-2b2d-e47f-d7a6"/>
     <categoryEntry name="Arco-flagellants" hidden="false" id="63f8-3a5d-ef9c-d86e"/>
@@ -5893,6 +5893,85 @@ Before making your selection, if this unit made a Charge move this turn, you can
         </profile>
       </profiles>
     </selectionEntry>
+    <selectionEntry type="unit" import="true" name="Death Cult Assassins [Legends]" hidden="false" id="fde5-930f-3040-4a81">
+      <costs>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="35"/>
+      </costs>
+      <categoryLinks>
+        <categoryLink targetId="cf47-a0d7-7207-29dc" id="9918-a479-71fc-11a2" primary="true" name="Infantry"/>
+        <categoryLink targetId="aff3-d6a3-2a95-9dc" id="4d75-9ccc-194e-5516" primary="false" name="Imperium"/>
+        <categoryLink targetId="bb32-4eb2-9e16-5c0" id="cd3d-67cf-27b1-12c4" primary="false" name="Death Cult Assassins"/>
+        <categoryLink targetId="fd71-afa6-b13b-7fda" id="5b41-df3d-8a98-b91b" primary="false" name="Faction: Adepta Sororitas"/>
+        <categoryLink targetId="e866-b72-7e3c-4aa9" id="e3bc-cba8-b1e1-8cd1" primary="false" name="Faction: Acts of Faith"/>
+      </categoryLinks>
+      <infoLinks>
+        <infoLink name="Acts of Faith" id="a50e-1726-9676-ce23" hidden="false" type="rule" targetId="7ef7-dca6-e2ea-ecc8"/>
+        <infoLink name="Fights First" id="86d0-0bf0-2914-879d" hidden="false" type="rule" targetId="24-c886-e8ba-5a89"/>
+        <infoLink name="Lone Operative" id="e64c-4696-5926-aba1" hidden="false" type="rule" targetId="a8a0-8fe7-898-e0f3"/>
+        <infoLink name="Death Cult Assassin" id="44b9-896d-a748-c15e" hidden="false" type="profile" targetId="2592-3a2-ec45-7000"/>
+      </infoLinks>
+      <profiles>
+        <profile name="Death Cult" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="720a-349b-ae53-be48">
+          <characteristics>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time a model in this unit makes an attack that targets a CHARACTER unit, you can re-roll the Wound roll.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoGroups>
+        <infoGroup name="Invulnerable Save" id="baaa-75f6-f993-c184" hidden="false">
+          <profiles>
+            <profile name="Invulnerable Save" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="81c4-d3f7-648a-6d7b">
+              <characteristics>
+                <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Models in this unit have an Invulnerable save of 5+.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+        </infoGroup>
+      </infoGroups>
+      <modifiers>
+        <modifier type="set" value="70" field="51b2-306e-1021-d207">
+          <conditions>
+            <condition type="atLeast" value="3" field="selections" scope="fde5-930f-3040-4a81" childId="model" shared="true" includeChildSelections="true" includeChildForces="true"/>
+            <condition type="atMost" value="4" field="selections" scope="fde5-930f-3040-4a81" childId="model" shared="true" includeChildSelections="true" includeChildForces="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" value="105" field="51b2-306e-1021-d207">
+          <conditions>
+            <condition type="atLeast" value="5" field="selections" scope="fde5-930f-3040-4a81" childId="model" shared="true" includeChildSelections="true" includeChildForces="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <entryLinks>
+        <entryLink import="true" name="Death Cult Assassin" hidden="false" id="9a5c-9383-9371-3507" type="selectionEntry" targetId="d643-d4f0-f626-7488"/>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry type="model" import="true" name="Death Cult Assassin" hidden="false" id="d643-d4f0-f626-7488">
+      <constraints>
+        <constraint type="min" value="2" field="selections" scope="parent" shared="true" id="94d4-5e02-f8b2-ba7d" includeChildSelections="false"/>
+        <constraint type="max" value="6" field="selections" scope="parent" shared="true" id="ea98-f683-ebc9-1955" includeChildSelections="false"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry type="upgrade" import="true" name="Death Cult power blade" hidden="false" id="bfbb-7d20-0118-7ebe" collective="true">
+          <profiles>
+            <profile name="Death Cult power blade" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="e092-bb42-7068-07e7">
+              <characteristics>
+                <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
+                <characteristic name="A" typeId="2337-daa1-6682-b110">4</characteristic>
+                <characteristic name="WS" typeId="95d1-95f-45b4-11d6">2+</characteristic>
+                <characteristic name="S" typeId="ab33-d393-96ce-ccba">4</characteristic>
+                <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-2</characteristic>
+                <characteristic name="D" typeId="3254-9fe6-d824-513e">1</characteristic>
+                <characteristic name="Keywords" typeId="893f-9000-ccf7-648e">Precision</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="fa7e-f0cd-9289-7cef" includeChildSelections="false"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="71e2-7102-1031-d3f2" includeChildSelections="false"/>
+          </constraints>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedProfiles>
     <profile name="Bolt Pistol" hidden="false" id="c934-fc40-d6a2-8919" typeName="Ranged Weapons" typeId="f77d-b953-8fa4-b762">
@@ -6105,7 +6184,7 @@ Before making your selection, if this unit made a Charge move this turn, you can
         <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">7&quot;</characteristic>
         <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">3</characteristic>
         <characteristic name="SV" typeId="450-a17e-9d5e-29da">5+</characteristic>
-        <characteristic name="W" typeId="750a-a2ec-90d3-21fe">1</characteristic>
+        <characteristic name="W" typeId="750a-a2ec-90d3-21fe">2</characteristic>
         <characteristic name="LD" typeId="58d2-b879-49c7-43bc">7+</characteristic>
         <characteristic name="OC" typeId="bef7-942a-1a23-59f8">1</characteristic>
       </characteristics>

--- a/Imperium - Adepta Sororitas.cat
+++ b/Imperium - Adepta Sororitas.cat
@@ -5904,16 +5904,32 @@ Before making your selection, if this unit made a Charge move this turn, you can
         <categoryLink targetId="fd71-afa6-b13b-7fda" id="5b41-df3d-8a98-b91b" primary="false" name="Faction: Adepta Sororitas"/>
         <categoryLink targetId="e866-b72-7e3c-4aa9" id="e3bc-cba8-b1e1-8cd1" primary="false" name="Faction: Acts of Faith"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry type="upgrade" import="true" name="Death Cult Assassins" hidden="false" id="da4b-a9bc-813a-5729">
+          <entryLinks>
+            <entryLink import="true" name="Death Cult Assassin" hidden="false" id="9a5c-9383-9371-3507" type="selectionEntry" targetId="d643-d4f0-f626-7488">
+              <constraints>
+                <constraint type="min" value="2" field="selections" scope="parent" shared="true" id="2559-c289-b762-be12"/>
+                <constraint type="max" value="6" field="selections" scope="parent" shared="true" id="46ec-a769-0d14-20c4" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="e74e-330d-9784-56cb" includeChildSelections="false"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9e06-9e50-e90f-4d1c" includeChildSelections="false"/>
+          </constraints>
+        </selectionEntry>
+      </selectionEntries>
       <infoLinks>
         <infoLink name="Acts of Faith" id="a50e-1726-9676-ce23" hidden="false" type="rule" targetId="7ef7-dca6-e2ea-ecc8"/>
         <infoLink name="Fights First" id="86d0-0bf0-2914-879d" hidden="false" type="rule" targetId="24-c886-e8ba-5a89"/>
         <infoLink name="Lone Operative" id="e64c-4696-5926-aba1" hidden="false" type="rule" targetId="a8a0-8fe7-898-e0f3"/>
-        <infoLink name="Death Cult Assassin" id="44b9-896d-a748-c15e" hidden="false" type="profile" targetId="2592-3a2-ec45-7000"/>
+        <infoLink name="Infiltrators" id="3802-5290-8229-c7fe" hidden="false" type="rule" targetId="c05d-f4c3-f091-4938"/>
       </infoLinks>
       <profiles>
         <profile name="Death Cult" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="720a-349b-ae53-be48">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time a model in this unit makes an attack that targets a CHARACTER unit, you can re-roll the Wound roll.</characteristic>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time a model in this unit makes an attack that targets a CHARACTER unit, you can re-roll the Wound roll.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -5931,25 +5947,18 @@ Before making your selection, if this unit made a Charge move this turn, you can
       <modifiers>
         <modifier type="set" value="70" field="51b2-306e-1021-d207">
           <conditions>
-            <condition type="atLeast" value="3" field="selections" scope="fde5-930f-3040-4a81" childId="model" shared="true" includeChildSelections="true" includeChildForces="true"/>
-            <condition type="atMost" value="4" field="selections" scope="fde5-930f-3040-4a81" childId="model" shared="true" includeChildSelections="true" includeChildForces="true"/>
+            <condition type="atLeast" value="3" field="selections" scope="fde5-930f-3040-4a81" childId="d643-d4f0-f626-7488" shared="true" includeChildSelections="true" includeChildForces="true"/>
+            <condition type="atMost" value="4" field="selections" scope="fde5-930f-3040-4a81" childId="9a5c-9383-9371-3507" shared="true" includeChildSelections="true" includeChildForces="true"/>
           </conditions>
         </modifier>
         <modifier type="set" value="105" field="51b2-306e-1021-d207">
           <conditions>
-            <condition type="atLeast" value="5" field="selections" scope="fde5-930f-3040-4a81" childId="model" shared="true" includeChildSelections="true" includeChildForces="true"/>
+            <condition type="atLeast" value="5" field="selections" scope="fde5-930f-3040-4a81" childId="d643-d4f0-f626-7488" shared="true" includeChildSelections="true" includeChildForces="true"/>
           </conditions>
         </modifier>
       </modifiers>
-      <entryLinks>
-        <entryLink import="true" name="Death Cult Assassin" hidden="false" id="9a5c-9383-9371-3507" type="selectionEntry" targetId="d643-d4f0-f626-7488"/>
-      </entryLinks>
     </selectionEntry>
     <selectionEntry type="model" import="true" name="Death Cult Assassin" hidden="false" id="d643-d4f0-f626-7488">
-      <constraints>
-        <constraint type="min" value="2" field="selections" scope="parent" shared="true" id="94d4-5e02-f8b2-ba7d" includeChildSelections="false"/>
-        <constraint type="max" value="6" field="selections" scope="parent" shared="true" id="ea98-f683-ebc9-1955" includeChildSelections="false"/>
-      </constraints>
       <selectionEntries>
         <selectionEntry type="upgrade" import="true" name="Death Cult power blade" hidden="false" id="bfbb-7d20-0118-7ebe" collective="true">
           <profiles>
@@ -5969,8 +5978,14 @@ Before making your selection, if this unit made a Charge move this turn, you can
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="fa7e-f0cd-9289-7cef" includeChildSelections="false"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="71e2-7102-1031-d3f2" includeChildSelections="false"/>
           </constraints>
+          <infoLinks>
+            <infoLink name="Precision" id="0135-309e-f5cb-2836" hidden="false" type="rule" targetId="9143-31ae-e0a6-6007"/>
+          </infoLinks>
         </selectionEntry>
       </selectionEntries>
+      <infoLinks>
+        <infoLink name="Death Cult Assassin" id="5bb7-87a8-1d5c-813f" hidden="false" type="profile" targetId="2592-3a2-ec45-7000"/>
+      </infoLinks>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedProfiles>


### PR DESCRIPTION
- Add DCA unit
- Add DCA model as shared entry
- decrease `atMost` condition for 70pts cost modifier from 5 to 4 (fix? At 5 the cost should increase to the 6-model cost)

Since GW introduced some changes with the Legends conversion, I thought I'd list them separately for clarity:
- decrease per 2 models cost from 45 to 35
- update model's wounds stat from 1 to 2
- add `Lone Operative` and `Infiltrators` rules
- Death Cult ability: can reroll wounds on any result instead of just 1's

Interestingly the the points update lists costs for 2,4 and 6 models, while the Legends datasheet lists 2-4 models for unit composition. Which way to do we want to rule on this one?

Finally, I'm new to contributing here and the tools, so please let me know if/what I need to tidy up.

#1361