### PR TITLE
Fixes #2486, Fixes #2479

### DIFF
--- a/Imperium - Adeptus Mechanicus.cat
+++ b/Imperium - Adeptus Mechanicus.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="77b9-2f66-3f9b-5cf3" name="Imperium - Adeptus Mechanicus" revision="46" battleScribeVersion="2.03" library="false" gameSystemId="sys-352e-adc2-7639-d6a9" gameSystemRevision="1" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="77b9-2f66-3f9b-5cf3" name="Imperium - Adeptus Mechanicus" revision="47" battleScribeVersion="2.03" library="false" gameSystemId="sys-352e-adc2-7639-d6a9" gameSystemRevision="1" type="catalogue">
   <categoryEntries>
     <categoryEntry id="f826-1ad1-a542-2058" name="Archaeopter Fusilave" hidden="false"/>
     <categoryEntry id="37b3-cded-c814-6e63" name="Archaeopter Stratoraptor" hidden="false"/>
@@ -844,7 +844,6 @@ Shroudpsalm (Aura): While a friendly Adeptus Mechanicus unit is within 6&quot; o
                   </profiles>
                   <infoLinks>
                     <infoLink name="Sustained Hits" hidden="false" type="rule" id="27bd-755c-71d6-3789" targetId="1897-c22c-9597-12b1"/>
-                    <infoLink name="Twin-linked" hidden="false" type="rule" id="5f22-4af8-b4b3-20bb" targetId="cf93-ad4d-2f08-a79d"/>
                   </infoLinks>
                   <constraints>
                     <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b40e-463f-170f-6069-min"/>
@@ -887,7 +886,6 @@ Shroudpsalm (Aura): While a friendly Adeptus Mechanicus unit is within 6&quot; o
                   </profiles>
                   <infoLinks>
                     <infoLink name="Sustained Hits" hidden="false" type="rule" id="4394-97cb-11d6-7f6a" targetId="1897-c22c-9597-12b1"/>
-                    <infoLink name="Twin-linked" hidden="false" type="rule" id="1c2c-d703-c4a7-1074" targetId="cf93-ad4d-2f08-a79d"/>
                   </infoLinks>
                   <constraints>
                     <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="caae-e06b-f880-7c9d-min"/>
@@ -4244,7 +4242,7 @@ as the target of a Stratagem, roll one D6: on a 5+, you gain 1CP.</characteristi
                         <characteristic name="S" typeId="2229-f494-25db-c5d3">5</characteristic>
                         <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
                         <characteristic name="D" typeId="a354-c1c8-a745-f9e3">2</characteristic>
-                        <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Ignores Cover</characteristic>
+                        <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Ignores Cover, Pistol</characteristic>
                       </characteristics>
                     </profile>
                   </profiles>
@@ -4392,7 +4390,7 @@ as the target of a Stratagem, roll one D6: on a 5+, you gain 1CP.</characteristi
                     <characteristic name="S" typeId="2229-f494-25db-c5d3">5</characteristic>
                     <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
                     <characteristic name="D" typeId="a354-c1c8-a745-f9e3">2</characteristic>
-                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Ignores Cover</characteristic>
+                    <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Ignores Cover, Pistol</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -6136,7 +6134,7 @@ Bodyguard unit, and that Bodyguard unit’s Starting Strength is increased acco
       <profiles>
         <profile id="f4a5-9d1d-2718-62e5" name="Torsion cannon" hidden="false" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons">
           <characteristics>
-            <characteristic name="Range" typeId="9896-9419-16a1-92fc">48&quot;</characteristic>
+            <characteristic name="Range" typeId="9896-9419-16a1-92fc">36&quot;</characteristic>
             <characteristic name="A" typeId="3bb-c35f-f54-fb08">D3</characteristic>
             <characteristic name="BS" typeId="94d-8a98-cf90-183e">4+</characteristic>
             <characteristic name="S" typeId="2229-f494-25db-c5d3">6</characteristic>
@@ -6515,7 +6513,7 @@ Bodyguard unit, and that Bodyguard unit’s Starting Strength is increased acco
                         <characteristic name="S" typeId="2229-f494-25db-c5d3">5</characteristic>
                         <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
                         <characteristic name="D" typeId="a354-c1c8-a745-f9e3">2</characteristic>
-                        <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Ignores Cover</characteristic>
+                        <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Ignores Cover, Pistol</characteristic>
                       </characteristics>
                     </profile>
                   </profiles>


### PR DESCRIPTION
- Added pistol keyword to phosphor serpenta
- Removed twin linked rule from Ironstrider Ballistarii
- Changed torsion cannon range from 48" to 36"