### PR TITLE
Storm Guardian rework

### DIFF
--- a/Aeldari - Aeldari Library.cat
+++ b/Aeldari - Aeldari Library.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="dfcf-1214-b57-2205" name="Aeldari - Aeldari Library" revision="71" battleScribeVersion="2.03" library="true" gameSystemId="sys-352e-adc2-7639-d6a9" gameSystemRevision="1" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="dfcf-1214-b57-2205" name="Aeldari - Aeldari Library" revision="72" battleScribeVersion="2.03" library="true" gameSystemId="sys-352e-adc2-7639-d6a9" gameSystemRevision="1" type="catalogue">
   <publications>
     <publication id="442c-a37c-3908-d701" name="Codex: Aeldari" shortName="C:Aeldari" publisher="Codex: Aeldari" publicationDate="08/02/2025"/>
     <publication id="1427-7c5c-863f-ac94" name="Index: Drukhari" shortName="I:Drukhari" publisher="Index: Drukhari" publicationDate="6/15/2023"/>
@@ -7638,276 +7638,65 @@ Attacks characteristic of this model’s Solitaire weapons.</characteristic>
                 <entryLink import="true" name="Shuriken Pistol" hidden="false" id="64bf-ad64-5f41-cabf" type="selectionEntry" targetId="6783-a483-98bc-4f87"/>
               </entryLinks>
             </selectionEntry>
-            <selectionEntry type="model" import="true" name="Storm Guardian with Aeldari Flamer" hidden="false" id="cef3-fc6a-ea66-c6fe">
-              <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Flamer" hidden="false" id="8269-a594-848c-36a9" collective="true">
-                  <profiles>
-                    <profile name="Flamer" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="9dcc-347-c99f-3db6">
-                      <characteristics>
-                        <characteristic name="Range" typeId="9896-9419-16a1-92fc">12&quot;</characteristic>
-                        <characteristic name="A" typeId="3bb-c35f-f54-fb08">D6</characteristic>
-                        <characteristic name="BS" typeId="94d-8a98-cf90-183e">N/A</characteristic>
-                        <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
-                        <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
-                        <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                        <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Assault, Ignores Cover, Torrent</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="187e-4cde-e6b8-75c7"/>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="382e-68d6-ec59-cb86"/>
-                  </constraints>
-                  <infoLinks>
-                    <infoLink name="Assault" hidden="false" type="rule" id="e794-a987-88d0-e30d" targetId="fc8a-8c24-bae9-cc1c"/>
-                    <infoLink name="Ignores Cover" hidden="false" type="rule" id="de27-a85a-7dca-4966" targetId="4640-43e7-30b-215a"/>
-                    <infoLink name="Torrent" hidden="false" type="rule" id="d680-1901-4a91-5b78" targetId="5edf-d619-23e0-9b56"/>
-                  </infoLinks>
-                </selectionEntry>
-              </selectionEntries>
+            <selectionEntry type="model" import="true" name="Storm Guardian with Flamer" hidden="false" id="cef3-fc6a-ea66-c6fe">
               <constraints>
                 <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="58dd-96e2-3bba-f83a"/>
               </constraints>
-              <modifiers>
-                <modifier type="decrement" value="1" field="58dd-96e2-3bba-f83a">
-                  <repeats>
-                    <repeat value="1" repeats="1" field="selections" scope="5452-c4a7-59fb-f05c" childId="5a90-5bed-c637-7f9e" shared="true" roundUp="false" includeChildForces="true" includeChildSelections="true"/>
-                  </repeats>
-                </modifier>
-              </modifiers>
               <infoLinks>
                 <infoLink name="Storm Guardian" id="c078-c242-ecc9-2f84" hidden="false" type="profile" targetId="ba06-c174-6710-248e"/>
               </infoLinks>
               <entryLinks>
                 <entryLink import="true" name="Close Combat Weapon" hidden="false" id="cd43-827f-ebdb-daa8" type="selectionEntry" targetId="6f5b-87a7-49f0-9721"/>
+                <entryLink import="true" name="Flamer" hidden="false" id="cf0f-e0e9-4e76-d35e" type="selectionEntry" targetId="8269-a594-848c-36a9"/>
               </entryLinks>
             </selectionEntry>
-            <selectionEntry type="model" import="true" name="Storm Guardian with Guardian Fusion Gun" hidden="false" id="8731-752d-3de9-6eb">
-              <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Fusion Gun" hidden="false" id="a36e-bee3-417a-6fb4" collective="true">
-                  <profiles>
-                    <profile name="Fusion Gun" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="6ff1-3647-9b24-5187">
-                      <characteristics>
-                        <characteristic name="Range" typeId="9896-9419-16a1-92fc">12&quot;</characteristic>
-                        <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
-                        <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                        <characteristic name="S" typeId="2229-f494-25db-c5d3">8</characteristic>
-                        <characteristic name="AP" typeId="9ead-8a10-520-de15">-4</characteristic>
-                        <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6</characteristic>
-                        <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Assault, Melta 2</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a02f-3c47-130c-536f"/>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="37a2-ea5f-a50-bb8e"/>
-                  </constraints>
-                  <infoLinks>
-                    <infoLink name="Assault" hidden="false" type="rule" id="8562-e37a-3d94-755f" targetId="fc8a-8c24-bae9-cc1c"/>
-                    <infoLink name="Melta" hidden="false" type="rule" id="46ff-3a8d-2ca1-394f" targetId="7cdb-fb99-44a9-8849"/>
-                  </infoLinks>
-                </selectionEntry>
-              </selectionEntries>
+            <selectionEntry type="model" import="true" name="Storm Guardian with Fusion Gun" hidden="false" id="8731-752d-3de9-6eb">
               <constraints>
                 <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="58dd-96e2-3bba-f83a"/>
               </constraints>
-              <modifiers>
-                <modifier type="decrement" value="1" field="58dd-96e2-3bba-f83a">
-                  <repeats>
-                    <repeat value="1" repeats="1" field="selections" scope="5452-c4a7-59fb-f05c" childId="0d79-6426-d369-775e" shared="true" roundUp="false" includeChildSelections="true" includeChildForces="true"/>
-                  </repeats>
-                </modifier>
-              </modifiers>
               <infoLinks>
                 <infoLink name="Storm Guardian" id="e71c-161f-7c0e-5397" hidden="false" type="profile" targetId="ba06-c174-6710-248e"/>
               </infoLinks>
               <entryLinks>
                 <entryLink import="true" name="Close Combat Weapon" hidden="false" id="56e9-5fa2-dee2-bb90" type="selectionEntry" targetId="6f5b-87a7-49f0-9721"/>
+                <entryLink import="true" name="Fusion Gun" hidden="false" id="a36f-0217-50f0-5744" type="selectionEntry" targetId="05aa-a5ee-9c87-d323"/>
               </entryLinks>
             </selectionEntry>
             <selectionEntry type="model" import="true" name="Storm Guardian with Power Sword" hidden="false" id="2f40-98b5-666c-3eef">
-              <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Power sword" hidden="false" id="0c83-9500-1b70-46d6" collective="true">
-                  <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8c3e-a19f-6aad-e929" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e3be-23ba-eea8-6d81" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
-                  </constraints>
-                  <profiles>
-                    <profile name="Power sword" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="b1f6-07bf-b55e-7573">
-                      <characteristics>
-                        <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
-                        <characteristic name="A" typeId="2337-daa1-6682-b110">2</characteristic>
-                        <characteristic name="WS" typeId="95d1-95f-45b4-11d6">3+</characteristic>
-                        <characteristic name="S" typeId="ab33-d393-96ce-ccba">4</characteristic>
-                        <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-2</characteristic>
-                        <characteristic name="D" typeId="3254-9fe6-d824-513e">1</characteristic>
-                        <characteristic name="Keywords" typeId="893f-9000-ccf7-648e">-</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <costs>
-                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
               <constraints>
                 <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="58dd-96e2-3bba-f83a"/>
               </constraints>
-              <modifiers>
-                <modifier type="decrement" value="1" field="58dd-96e2-3bba-f83a">
-                  <repeats>
-                    <repeat value="1" repeats="1" field="selections" scope="5452-c4a7-59fb-f05c" childId="0d79-6426-d369-775e" shared="true" roundUp="false" includeChildForces="true" includeChildSelections="true"/>
-                  </repeats>
-                </modifier>
-                <modifier type="decrement" value="1" field="58dd-96e2-3bba-f83a">
-                  <repeats>
-                    <repeat value="1" repeats="1" field="selections" scope="5452-c4a7-59fb-f05c" childId="5a90-5bed-c637-7f9e" shared="true" roundUp="false" includeChildSelections="true" includeChildForces="true"/>
-                  </repeats>
-                </modifier>
-              </modifiers>
               <infoLinks>
                 <infoLink name="Storm Guardian" id="089e-b779-0385-7d4e" hidden="false" type="profile" targetId="ba06-c174-6710-248e"/>
               </infoLinks>
               <entryLinks>
                 <entryLink import="true" name="Shuriken Pistol" hidden="false" id="3781-1a24-eff9-8af1" type="selectionEntry" targetId="6783-a483-98bc-4f87"/>
+                <entryLink import="true" name="Power sword" hidden="false" id="bd14-7da1-a80f-140b" type="selectionEntry" targetId="0e77-2630-6f58-75ce"/>
               </entryLinks>
             </selectionEntry>
-            <selectionEntry type="model" import="true" name="Storm Guardian with Aeldari Flamer &amp; Power Sword" hidden="false" id="5a90-5bed-c637-7f9e">
-              <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Power sword" hidden="false" id="0e77-2630-6f58-75ce" collective="true">
-                  <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="a695-ef1f-617a-8751" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="85bc-5483-4ace-fe17" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
-                  </constraints>
-                  <profiles>
-                    <profile name="Power sword" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="eacd-1888-b8c7-ee56">
-                      <characteristics>
-                        <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
-                        <characteristic name="A" typeId="2337-daa1-6682-b110">2</characteristic>
-                        <characteristic name="WS" typeId="95d1-95f-45b4-11d6">3+</characteristic>
-                        <characteristic name="S" typeId="ab33-d393-96ce-ccba">4</characteristic>
-                        <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-2</characteristic>
-                        <characteristic name="D" typeId="3254-9fe6-d824-513e">1</characteristic>
-                        <characteristic name="Keywords" typeId="893f-9000-ccf7-648e">-</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <costs>
-                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Flamer" hidden="false" id="8017-db55-2a20-2fc2" collective="true">
-                  <profiles>
-                    <profile name="Flamer" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="75fa-2373-9319-c4c2">
-                      <characteristics>
-                        <characteristic name="Range" typeId="9896-9419-16a1-92fc">12&quot;</characteristic>
-                        <characteristic name="A" typeId="3bb-c35f-f54-fb08">D6</characteristic>
-                        <characteristic name="BS" typeId="94d-8a98-cf90-183e">N/A</characteristic>
-                        <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
-                        <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
-                        <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
-                        <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Assault, Ignores Cover, Torrent</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="026d-5acf-4a0b-05cc"/>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="1472-9861-1c17-3db0"/>
-                  </constraints>
-                  <infoLinks>
-                    <infoLink name="Assault" id="fdb8-cd0e-3948-3afe" hidden="false" type="rule" targetId="fc8a-8c24-bae9-cc1c"/>
-                    <infoLink name="Ignores Cover" id="6564-37bf-6d96-58d1" hidden="false" type="rule" targetId="4640-43e7-30b-215a"/>
-                    <infoLink name="Torrent" id="e33e-363e-15a2-af2d" hidden="false" type="rule" targetId="5edf-d619-23e0-9b56"/>
-                  </infoLinks>
-                </selectionEntry>
-              </selectionEntries>
+            <selectionEntry type="model" import="true" name="Storm Guardian with Flamer &amp; Power Sword" hidden="false" id="5a90-5bed-c637-7f9e">
               <constraints>
                 <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="d906-e42d-18a5-7e25"/>
               </constraints>
-              <modifiers>
-                <modifier type="decrement" value="1" field="d906-e42d-18a5-7e25">
-                  <repeats>
-                    <repeat value="1" repeats="1" field="selections" scope="5452-c4a7-59fb-f05c" childId="cef3-fc6a-ea66-c6fe" shared="true" roundUp="false" includeChildForces="true" includeChildSelections="true"/>
-                  </repeats>
-                </modifier>
-                <modifier type="decrement" value="1" field="d906-e42d-18a5-7e25">
-                  <repeats>
-                    <repeat value="1" repeats="1" field="selections" scope="5452-c4a7-59fb-f05c" childId="2f40-98b5-666c-3eef" shared="true" roundUp="false" includeChildSelections="true" includeChildForces="true"/>
-                    <repeat value="1" repeats="1" field="selections" scope="5452-c4a7-59fb-f05c" childId="0d79-6426-d369-775e" shared="true" roundUp="false" includeChildSelections="true" includeChildForces="true"/>
-                  </repeats>
-                </modifier>
-              </modifiers>
               <infoLinks>
                 <infoLink name="Storm Guardian" id="cd0a-96e0-1342-92c4" hidden="false" type="profile" targetId="ba06-c174-6710-248e"/>
               </infoLinks>
+              <entryLinks>
+                <entryLink import="true" name="Flamer" hidden="false" id="7bd6-ada8-1e1d-048f" type="selectionEntry" targetId="8269-a594-848c-36a9"/>
+                <entryLink import="true" name="Power sword" hidden="false" id="5bee-83e2-ca92-18ed" type="selectionEntry" targetId="0e77-2630-6f58-75ce"/>
+              </entryLinks>
             </selectionEntry>
-            <selectionEntry type="model" import="true" name="Storm Guardian with Guardian Fusion Gun &amp; Power Sword" hidden="false" id="0d79-6426-d369-775e">
-              <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Power sword" hidden="false" id="e305-4541-19ec-d453" collective="true">
-                  <constraints>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="9840-dc0f-d413-96ff" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2475-b262-147a-85e9" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
-                  </constraints>
-                  <profiles>
-                    <profile name="Power sword" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="e8a3-3679-a3a4-2c64">
-                      <characteristics>
-                        <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
-                        <characteristic name="A" typeId="2337-daa1-6682-b110">2</characteristic>
-                        <characteristic name="WS" typeId="95d1-95f-45b4-11d6">3+</characteristic>
-                        <characteristic name="S" typeId="ab33-d393-96ce-ccba">4</characteristic>
-                        <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-2</characteristic>
-                        <characteristic name="D" typeId="3254-9fe6-d824-513e">1</characteristic>
-                        <characteristic name="Keywords" typeId="893f-9000-ccf7-648e">-</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <costs>
-                    <cost name="pts" typeId="51b2-306e-1021-d207" value="0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Fusion Gun" hidden="false" id="05aa-a5ee-9c87-d323" collective="true">
-                  <profiles>
-                    <profile name="Fusion Gun" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="dd1c-f7db-6985-f4c9">
-                      <characteristics>
-                        <characteristic name="Range" typeId="9896-9419-16a1-92fc">12&quot;</characteristic>
-                        <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
-                        <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
-                        <characteristic name="S" typeId="2229-f494-25db-c5d3">8</characteristic>
-                        <characteristic name="AP" typeId="9ead-8a10-520-de15">-4</characteristic>
-                        <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6</characteristic>
-                        <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Assault, Melta 2</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="54fa-9ccf-8d9e-e6ee"/>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="e14d-641d-8a73-c86e"/>
-                  </constraints>
-                  <infoLinks>
-                    <infoLink name="Assault" id="6a45-5dde-369b-195a" hidden="false" type="rule" targetId="fc8a-8c24-bae9-cc1c"/>
-                    <infoLink name="Melta" id="6fcf-ab92-0cf3-bc72" hidden="false" type="rule" targetId="7cdb-fb99-44a9-8849"/>
-                  </infoLinks>
-                </selectionEntry>
-              </selectionEntries>
+            <selectionEntry type="model" import="true" name="Storm Guardian with Fusion Gun &amp; Power Sword" hidden="false" id="0d79-6426-d369-775e">
               <constraints>
                 <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="7fa2-0b0b-b5f8-e36e"/>
               </constraints>
-              <modifiers>
-                <modifier type="decrement" value="1" field="7fa2-0b0b-b5f8-e36e">
-                  <repeats>
-                    <repeat value="1" repeats="1" field="selections" scope="5452-c4a7-59fb-f05c" childId="2f40-98b5-666c-3eef" shared="true" roundUp="false" includeChildSelections="true" includeChildForces="true"/>
-                    <repeat value="1" repeats="1" field="selections" scope="5452-c4a7-59fb-f05c" childId="5a90-5bed-c637-7f9e" shared="true" roundUp="false" includeChildSelections="true" includeChildForces="true"/>
-                  </repeats>
-                </modifier>
-                <modifier type="decrement" value="1" field="7fa2-0b0b-b5f8-e36e">
-                  <repeats>
-                    <repeat value="1" repeats="1" field="selections" scope="5452-c4a7-59fb-f05c" childId="8731-752d-3de9-6eb" shared="true" roundUp="false" includeChildSelections="true" includeChildForces="true"/>
-                  </repeats>
-                </modifier>
-              </modifiers>
               <infoLinks>
                 <infoLink name="Storm Guardian" id="79fd-f191-5a31-7ab2" hidden="false" type="profile" targetId="ba06-c174-6710-248e"/>
               </infoLinks>
+              <entryLinks>
+                <entryLink import="true" name="Power sword" hidden="false" id="03d6-5f76-652f-297c" type="selectionEntry" targetId="0e77-2630-6f58-75ce"/>
+                <entryLink import="true" name="Fusion Gun" hidden="false" id="421d-b96d-fb0d-f7e6" type="selectionEntry" targetId="05aa-a5ee-9c87-d323"/>
+              </entryLinks>
             </selectionEntry>
           </selectionEntries>
           <constraints>
@@ -25605,6 +25394,79 @@ For every 5 models in this unit, it can have 1 Aspect Shrine token.</characteris
           </conditionGroups>
         </modifier>
       </modifiers>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Flamer" hidden="false" id="8269-a594-848c-36a9" collective="true">
+      <profiles>
+        <profile name="Flamer" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="9dcc-347-c99f-3db6">
+          <characteristics>
+            <characteristic name="Range" typeId="9896-9419-16a1-92fc">12&quot;</characteristic>
+            <characteristic name="A" typeId="3bb-c35f-f54-fb08">D6</characteristic>
+            <characteristic name="BS" typeId="94d-8a98-cf90-183e">N/A</characteristic>
+            <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
+            <characteristic name="AP" typeId="9ead-8a10-520-de15">0</characteristic>
+            <characteristic name="D" typeId="a354-c1c8-a745-f9e3">1</characteristic>
+            <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Assault, Ignores Cover, Torrent</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <constraints>
+        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="187e-4cde-e6b8-75c7"/>
+        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="382e-68d6-ec59-cb86"/>
+        <constraint type="max" value="2" field="selections" scope="5452-c4a7-59fb-f05c" shared="true" id="e6e8-8476-4b7c-0696" includeChildSelections="true"/>
+      </constraints>
+      <infoLinks>
+        <infoLink name="Assault" id="e794-a987-88d0-e30d" hidden="false" type="rule" targetId="fc8a-8c24-bae9-cc1c"/>
+        <infoLink name="Ignores Cover" id="de27-a85a-7dca-4966" hidden="false" type="rule" targetId="4640-43e7-30b-215a"/>
+        <infoLink name="Torrent" id="d680-1901-4a91-5b78" hidden="false" type="rule" targetId="5edf-d619-23e0-9b56"/>
+      </infoLinks>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Power sword" hidden="false" id="0e77-2630-6f58-75ce" collective="true">
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="a695-ef1f-617a-8751" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="85bc-5483-4ace-fe17" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+        <constraint type="max" value="2" field="selections" scope="5452-c4a7-59fb-f05c" shared="true" id="7274-7678-92c0-4e73" includeChildSelections="true"/>
+      </constraints>
+      <profiles>
+        <profile name="Power sword" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="eacd-1888-b8c7-ee56">
+          <characteristics>
+            <characteristic name="Range" typeId="914c-b413-91e3-a132">Melee</characteristic>
+            <characteristic name="A" typeId="2337-daa1-6682-b110">2</characteristic>
+            <characteristic name="WS" typeId="95d1-95f-45b4-11d6">3+</characteristic>
+            <characteristic name="S" typeId="ab33-d393-96ce-ccba">4</characteristic>
+            <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-2</characteristic>
+            <characteristic name="D" typeId="3254-9fe6-d824-513e">1</characteristic>
+            <characteristic name="Keywords" typeId="893f-9000-ccf7-648e">-</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="0"/>
+      </costs>
+      <comment>Storm Guardians</comment>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Fusion Gun" hidden="false" id="05aa-a5ee-9c87-d323" collective="true">
+      <profiles>
+        <profile name="Fusion Gun" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="dd1c-f7db-6985-f4c9">
+          <characteristics>
+            <characteristic name="Range" typeId="9896-9419-16a1-92fc">12&quot;</characteristic>
+            <characteristic name="A" typeId="3bb-c35f-f54-fb08">1</characteristic>
+            <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+            <characteristic name="S" typeId="2229-f494-25db-c5d3">8</characteristic>
+            <characteristic name="AP" typeId="9ead-8a10-520-de15">-4</characteristic>
+            <characteristic name="D" typeId="a354-c1c8-a745-f9e3">D6</characteristic>
+            <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Assault, Melta 2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <constraints>
+        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="54fa-9ccf-8d9e-e6ee"/>
+        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="e14d-641d-8a73-c86e"/>
+        <constraint type="max" value="2" field="selections" scope="5452-c4a7-59fb-f05c" shared="true" id="ac4a-360a-2631-1c37" includeChildSelections="true"/>
+      </constraints>
+      <infoLinks>
+        <infoLink name="Assault" id="6a45-5dde-369b-195a" hidden="false" type="rule" targetId="fc8a-8c24-bae9-cc1c"/>
+        <infoLink name="Melta" id="6fcf-ab92-0cf3-bc72" hidden="false" type="rule" targetId="7cdb-fb99-44a9-8849"/>
+      </infoLinks>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>


### PR DESCRIPTION
Moved common weapons over to being shared entries and added "max 2 in Storm Guardians" constraints to them then removed all decrements from models in unit.