### PR TITLE
Update Imperium - Astra Militarum - Library.cat

### DIFF
--- a/Imperium - Astra Militarum - Library.cat
+++ b/Imperium - Astra Militarum - Library.cat
@@ -19538,7 +19538,7 @@ Designer&apos;s Note: Place a Servo-scribes token next to the unit, removing it 
       <profiles>
         <profile name="Final Duty" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="afd7-1aee-c637-14c8">
           <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While the Fire Coordinator model is on the battlefield, each time a Heavy Weapons Gunner model is destroyed, roll one D6: one a 3+, do remove it from play. The destroyed model can shoot after the attacking model&apos;s unit has finished making its attacks, and is then removed from play.</characteristic>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While the Fire Coordinator model is on the battlefield, each time a Heavy Weapons Gunner model is destroyed, roll one D6: on a 3+, do not remove it from play. The destroyed model can shoot after the attacking model&apos;s unit has finished making its attacks, and is then removed from play.</characteristic>
           </characteristics>
         </profile>
       </profiles>


### PR DESCRIPTION
Fix description for Final Duty ability of Krieg HWT. Currently says "one a 3+, do remove" instead of "on a 3+, do not remove" as it should.