### PR TITLE
Death Company Fixes and Tycho the Lost

### DIFF
--- a/Imperium - Blood Angels.cat
+++ b/Imperium - Blood Angels.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="4ef9-15ce-e3e6-36de" name="Imperium - Adeptus Astartes - Blood Angels" gameSystemId="sys-352e-adc2-7639-d6a9" gameSystemRevision="1" revision="42" battleScribeVersion="2.03" type="catalogue" authorName="Acebaur">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="4ef9-15ce-e3e6-36de" name="Imperium - Adeptus Astartes - Blood Angels" gameSystemId="sys-352e-adc2-7639-d6a9" gameSystemRevision="1" revision="43" battleScribeVersion="2.03" type="catalogue" authorName="Acebaur">
   <catalogueLinks>
     <catalogueLink type="catalogue" name="Imperium - Space Marines" id="abd0-8ebd-6fbd-2d94" targetId="e0af-67df-9d63-8fb7" importRootEntries="true"/>
     <catalogueLink type="catalogue" name="Imperium - Imperial Knights - Library" id="9c08-8ffc-d746-7384" targetId="1b6d-dc06-5db9-c7d1" importRootEntries="true"/>
@@ -621,7 +621,7 @@
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="model" import="true" name="Tycho the Lost [Legends]" hidden="true" id="8577-8a5d-75f6-a630">
+    <selectionEntry type="model" import="true" name="Tycho the Lost [Legends]" hidden="false" id="8577-8a5d-75f6-a630">
       <constraints>
         <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="96ce-1ad2-d58f-e368"/>
       </constraints>
@@ -5128,7 +5128,6 @@ If a Character unit from your army with the Leader ability can be attached to a
     <categoryEntry name="Sanguinary Guard" hidden="false" id="d30a-a7c5-389a-e78"/>
     <categoryEntry name="Sanguinary Priest with Jump Pack" hidden="false" id="d2c6-5062-e0b8-9e20"/>
     <categoryEntry name="The Sanguinor" hidden="false" id="8f39-9585-fc72-ba71"/>
-    <categoryEntry name="Death Company" id="1e3d-c738-8087-792c" hidden="false"/>
     <categoryEntry name="Death Company Marines with Bolt Rifles" id="3055-9a0b-b062-5f31" hidden="false"/>
     <categoryEntry name="Pistol replacement" id="f06c-dfec-c720-57f1" hidden="true"/>
     <categoryEntry name="Death Company Marines with Boltguns" hidden="false" id="d57c-d980-bdae-2999"/>

--- a/Imperium - Space Marines.cat
+++ b/Imperium - Space Marines.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="e0af-67df-9d63-8fb7" name="Imperium - Adeptus Astartes - Space Marines" revision="102" battleScribeVersion="2.03" library="false" gameSystemId="sys-352e-adc2-7639-d6a9" gameSystemRevision="1" type="catalogue" authorName="Acebaur">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="e0af-67df-9d63-8fb7" name="Imperium - Adeptus Astartes - Space Marines" revision="103" battleScribeVersion="2.03" library="false" gameSystemId="sys-352e-adc2-7639-d6a9" gameSystemRevision="1" type="catalogue" authorName="Acebaur">
   <categoryEntries>
     <categoryEntry id="5179-8ede-45e3-49a2" name="Tacticus" hidden="false"/>
     <categoryEntry id="930d-2875-125b-a65e" name="Bladeguard Veteran Squad" hidden="false"/>
@@ -122,6 +122,7 @@
     <categoryEntry name="Biologis" id="6820-5587-dd68-4d0f" hidden="false"/>
     <categoryEntry name="Watch Master" id="6e-71bd-2538-d468" hidden="false"/>
     <categoryEntry name="Sanguinary Priest" id="561f-8606-9555-b3ba" hidden="false"/>
+    <categoryEntry name="Death Company" id="1e3d-c738-8087-792c" hidden="false"/>
   </categoryEntries>
   <entryLinks>
     <entryLink import="true" name="Detachment" hidden="false" type="selectionEntry" id="e9ed-6763-ea0d-39fe" targetId="82cb-ba1-1aae-3b1d"/>
@@ -39392,6 +39393,13 @@ is Battle-shocked, models in that unit have the Feel No Pain 4+ ability instead.
                 <cost name="Crusade: Experience" typeId="a623-fe74-1d33-cddf" value="0"/>
                 <cost name="Crusade: Weapon Modifications" typeId="716d-91b7-d55a-1022" value="0"/>
               </costs>
+              <modifiers>
+                <modifier type="set" value="true" field="hidden">
+                  <conditions>
+                    <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="1e3d-c738-8087-792c" shared="true"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
             </selectionEntry>
             <selectionEntry type="upgrade" import="true" name="Sanguinius&apos; Grace" hidden="false" id="d4bd-87c4-6825-c07e">
               <constraints>
@@ -39411,6 +39419,13 @@ is Battle-shocked, models in that unit have the Feel No Pain 4+ ability instead.
                 <cost name="Crusade: Experience" typeId="a623-fe74-1d33-cddf" value="0"/>
                 <cost name="Crusade: Weapon Modifications" typeId="716d-91b7-d55a-1022" value="0"/>
               </costs>
+              <modifiers>
+                <modifier type="set" value="true" field="hidden">
+                  <conditions>
+                    <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="1e3d-c738-8087-792c" shared="true"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
             </selectionEntry>
             <selectionEntry type="upgrade" import="true" name="To Slay the Warmaster" hidden="false" id="1141-0c39-2208-da0f">
               <constraints>
@@ -39430,6 +39445,13 @@ is Battle-shocked, models in that unit have the Feel No Pain 4+ ability instead.
                 <cost name="Crusade: Experience" typeId="a623-fe74-1d33-cddf" value="0"/>
                 <cost name="Crusade: Weapon Modifications" typeId="716d-91b7-d55a-1022" value="0"/>
               </costs>
+              <modifiers>
+                <modifier type="set" value="true" field="hidden">
+                  <conditions>
+                    <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="1e3d-c738-8087-792c" shared="true"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
             </selectionEntry>
             <selectionEntry type="upgrade" import="true" name="Vengeful Onslaught" hidden="false" id="24ca-aa0a-625a-34a1">
               <constraints>
@@ -39449,6 +39471,13 @@ is Battle-shocked, models in that unit have the Feel No Pain 4+ ability instead.
                 <cost name="Crusade: Experience" typeId="a623-fe74-1d33-cddf" value="0"/>
                 <cost name="Crusade: Weapon Modifications" typeId="716d-91b7-d55a-1022" value="0"/>
               </costs>
+              <modifiers>
+                <modifier type="set" value="true" field="hidden">
+                  <conditions>
+                    <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="1e3d-c738-8087-792c" shared="true"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
             </selectionEntry>
           </selectionEntries>
           <constraints>


### PR DESCRIPTION
This moves the Death Company tag to the Space Marine catalogue (following the same format as the Ravenwing or Deathwing tags), which lets the enhancements for Lost Brethren be locked to Death Company in the same way as other Chapter's enhancements. It also unhides Tycho the Lost since he still has a valid Legends datasheet.

Fixes #3848 
Fixes #3849 