### PR TITLE
4406 adeptus mechanicus dataslate

### DIFF
--- a/Imperium - Adeptus Mechanicus.cat
+++ b/Imperium - Adeptus Mechanicus.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="77b9-2f66-3f9b-5cf3" name="Imperium - Adeptus Mechanicus" revision="62" battleScribeVersion="2.03" library="false" gameSystemId="sys-352e-adc2-7639-d6a9" gameSystemRevision="1" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="77b9-2f66-3f9b-5cf3" name="Imperium - Adeptus Mechanicus" revision="63" battleScribeVersion="2.03" library="false" gameSystemId="sys-352e-adc2-7639-d6a9" gameSystemRevision="1" type="catalogue">
   <categoryEntries>
     <categoryEntry id="f826-1ad1-a542-2058" name="Archaeopter Fusilave" hidden="false"/>
     <categoryEntry id="37b3-cded-c814-6e63" name="Archaeopter Stratoraptor" hidden="false"/>
@@ -819,7 +819,7 @@ Shroudpsalm (Aura): While a friendly Adeptus Mechanicus unit is within 6&quot; o
           <selectionEntries>
             <selectionEntry id="2d5d-40b5-4ac8-cedc" name="Ironstrider Ballistarius (Twin cognis autocannon)" hidden="false" collective="false" import="true" type="model">
               <costs>
-                <cost name="pts" typeId="51b2-306e-1021-d207" value="75"/>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="70"/>
                 <cost name="Crusade Points" typeId="b03b-c239-15a5-da55" value="0"/>
                 <cost name="Crusade: Battle Honours" typeId="75bb-ded1-c86d-bdf0" value="0"/>
                 <cost name="Crusade: Experience" typeId="a623-fe74-1d33-cddf" value="0"/>
@@ -858,7 +858,7 @@ Shroudpsalm (Aura): While a friendly Adeptus Mechanicus unit is within 6&quot; o
             </selectionEntry>
             <selectionEntry id="8fc1-9168-5137-2b5d" name="Ironstrider Ballistarius (Twin cognis lascannon)" hidden="false" collective="false" import="true" type="model">
               <costs>
-                <cost name="pts" typeId="51b2-306e-1021-d207" value="75"/>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="70"/>
                 <cost name="Crusade Points" typeId="b03b-c239-15a5-da55" value="0"/>
                 <cost name="Crusade: Battle Honours" typeId="75bb-ded1-c86d-bdf0" value="0"/>
                 <cost name="Crusade: Experience" typeId="a623-fe74-1d33-cddf" value="0"/>
@@ -942,6 +942,7 @@ Shroudpsalm (Aura): While a friendly Adeptus Mechanicus unit is within 6&quot; o
             <modifier type="append" value="1" field="name"/>
           </modifiers>
         </infoLink>
+        <infoLink name="Doctrina Imperatives" id="2b57-7350-0d94-a2d7" hidden="false" type="rule" targetId="7a21-a958-e47d-5c0d"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="ae73-8a7-dac0-996" name="Kastelan Robots" hidden="false" targetId="fa9a-4fad-2efa-cf9b" primary="false"/>
@@ -3999,7 +4000,11 @@ as the target of a Stratagem, roll one D6: on a 5+, you gain 1CP.</characteristi
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="pts" typeId="51b2-306e-1021-d207" value="175"/>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="165"/>
+        <cost name="Crusade Points" typeId="b03b-c239-15a5-da55" value="0"/>
+        <cost name="Crusade: Battle Honours" typeId="75bb-ded1-c86d-bdf0" value="0"/>
+        <cost name="Crusade: Experience" typeId="a623-fe74-1d33-cddf" value="0"/>
+        <cost name="Crusade: Weapon Modifications" typeId="716d-91b7-d55a-1022" value="0"/>
       </costs>
       <infoLinks>
         <infoLink name="Deadly Demise" hidden="false" type="rule" id="3702-968f-7b40-2ed8" targetId="b68a-5ded-65ac-98c">
@@ -4167,7 +4172,11 @@ as the target of a Stratagem, roll one D6: on a 5+, you gain 1CP.</characteristi
           <selectionEntries>
             <selectionEntry id="54c7-b18a-e3b6-0431" name="Sydonian Dragoon with taser lance" hidden="false" collective="false" import="true" type="model">
               <costs>
-                <cost name="pts" typeId="51b2-306e-1021-d207" value="70"/>
+                <cost name="pts" typeId="51b2-306e-1021-d207" value="65"/>
+                <cost name="Crusade Points" typeId="b03b-c239-15a5-da55" value="0"/>
+                <cost name="Crusade: Battle Honours" typeId="75bb-ded1-c86d-bdf0" value="0"/>
+                <cost name="Crusade: Experience" typeId="a623-fe74-1d33-cddf" value="0"/>
+                <cost name="Crusade: Weapon Modifications" typeId="716d-91b7-d55a-1022" value="0"/>
               </costs>
               <selectionEntries>
                 <selectionEntry type="upgrade" import="true" name="Phosphor serpenta" hidden="false" id="2b6c-ae66-8e2e-493b" collective="true">
@@ -4830,6 +4839,7 @@ You must attach this model to a Kastelan Robots unit, even if one or more other 
       </profiles>
       <infoLinks>
         <infoLink id="988b-6754-07c4-8c45" name="Leader" hidden="false" targetId="b4dd-3e1f-41cb-218f" type="rule"/>
+        <infoLink name="Doctrina Imperatives" id="51fb-38a2-8605-5112" hidden="false" type="rule" targetId="7a21-a958-e47d-5c0d"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="c3db-c71e-5f3f-c184" name="Cybernetica Datasmith" hidden="false" targetId="6785-add8-89f-d960" primary="false"/>
@@ -5851,7 +5861,7 @@ Each time a CULT MECHANICUS unit from your army is selected to fight, if that u
             <selectionEntry type="upgrade" import="true" name="Cohort Cybernetica" hidden="false" id="f67d-6f59-21b8-e1f9">
               <rules>
                 <rule name="Cyber Psalm-Programming" hidden="false" id="6cd2-7fa1-3feb-5b8b">
-                  <description>LEGIO CYBERNETICA units from your army gain the Doctrina Imperatives army rule.</description>
+                  <description>Add 2&quot; to the Move characteristic of models in LEGIO CYBERNETICA units from your army. In addition, unless that unit is Battle‑shocked, add 1 to the Objective Control characteristic of models in that unit.</description>
                 </rule>
               </rules>
             </selectionEntry>
@@ -7380,7 +7390,7 @@ Bodyguard unit, and that Bodyguard unit’s Starting Strength is increased acco
             </modifier>
           </modifiers>
           <costs>
-            <cost name="pts" typeId="51b2-306e-1021-d207" value="30"/>
+            <cost name="pts" typeId="51b2-306e-1021-d207" value="15"/>
             <cost name="Crusade Points" typeId="b03b-c239-15a5-da55" value="0"/>
             <cost name="Crusade: Battle Honours" typeId="75bb-ded1-c86d-bdf0" value="0"/>
             <cost name="Crusade: Experience" typeId="a623-fe74-1d33-cddf" value="0"/>
@@ -7389,7 +7399,7 @@ Bodyguard unit, and that Bodyguard unit’s Starting Strength is increased acco
           <profiles>
             <profile name="Transoracular Dyad Wafers" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="96b7-429d-f947-3015">
               <characteristics>
-                <characteristic name="Description" typeId="9b8f-694b-e5e-b573">CYBERNETICA DATASMITH model only. When the bearer is attached to a KASTELAN ROBOTS unit, until the end of the battle, models in that unit have the Doctrina Imperatives ability and gain the Halo Override keyword. This unit cannot be selected when selecting units as part of the Noospheric Transference Detachment rule.</characteristic>
+                <characteristic name="Description" typeId="9b8f-694b-e5e-b573">CYBERNETICA DATASMITH model only. When the bearer is attached to a KASTELAN ROBOTS unit, until the end of the battle, models in that unit and gain the Halo Override keyword. That unit cannot be selected when selecting units as part of the Noospheric Transference Detachment rule.</characteristic>
               </characteristics>
             </profile>
           </profiles>

--- a/Imperium - Adeptus Mechanicus.cat
+++ b/Imperium - Adeptus Mechanicus.cat
@@ -7399,7 +7399,7 @@ Bodyguard unit, and that Bodyguard unit’s Starting Strength is increased acco
           <profiles>
             <profile name="Transoracular Dyad Wafers" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="96b7-429d-f947-3015">
               <characteristics>
-                <characteristic name="Description" typeId="9b8f-694b-e5e-b573">CYBERNETICA DATASMITH model only. When the bearer is attached to a KASTELAN ROBOTS unit, until the end of the battle, models in that unit and gain the Halo Override keyword. That unit cannot be selected when selecting units as part of the Noospheric Transference Detachment rule.</characteristic>
+                <characteristic name="Description" typeId="9b8f-694b-e5e-b573">CYBERNETICA DATASMITH model only. When the bearer is attached to a KASTELAN ROBOTS unit, until the end of the battle, models in that unit gain the Halo Override keyword. That unit cannot be selected when selecting units as part of the Noospheric Transference Detachment rule.</characteristic>
               </characteristics>
             </profile>
           </profiles>


### PR DESCRIPTION
- reduced points cost of Ironstrider Ballistarii to 70
- reduced points cost of Sydonian Dragoons with Taser Lances to 65
- reduced points cost of Skorpius Disintegrator to 165
- reduced points cost of Transoracular Dyad Wafers to 15
- added Doctrina Imperatives to Kastelan Robots and Cybernetica Datasmith
- updated Cyber-psalm Programming Detachment Rule
- updated Transoracular Dyad Wafers Enhancement