### PR TITLE
Fix outdated Black Rage rules text

### DIFF
--- a/Imperium - Blood Angels.cat
+++ b/Imperium - Blood Angels.cat
@@ -5140,7 +5140,7 @@ If a Character unit from your army with the Leader ability can be attached to a
   <sharedProfiles>
     <profile name="Black Rage" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="3e0a-31f-8be-e293">
       <characteristics>
-        <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time this model makes a melee attack, you can re-roll the Hit roll. While this model&apos;s unit is not within 6&quot; of one or more friendly BLOOD ANGEL CHARACTER models, or 12&quot; of one or more friendly Chaplain models, it cannot be selected to Fall Back and the Objective Control characteristic of models in this unit is 0.</characteristic>
+        <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time this model makes a melee attack, you can re-roll the Hit roll. While this model&apos;s unit is not within 6&quot; of one or more friendly ^^**Blood Angels Character**^^ models, or 12&quot; of one or more friendly ^^**Chaplain**^^ models, it cannot be selected to Fall Back and the Objective Control characteristic of models in this unit is 0.</characteristic>
       </characteristics>
     </profile>
     <profile name="Visions of Heresy" hidden="false" id="6b69-8f10-6d74-706c" typeName="Abilities" typeId="9cc3-6d83-4dd3-9b64">

--- a/Imperium - Blood Angels.cat
+++ b/Imperium - Blood Angels.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="4ef9-15ce-e3e6-36de" name="Imperium - Adeptus Astartes - Blood Angels" gameSystemId="sys-352e-adc2-7639-d6a9" gameSystemRevision="1" revision="46" battleScribeVersion="2.03" type="catalogue" authorName="Acebaur">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="4ef9-15ce-e3e6-36de" name="Imperium - Adeptus Astartes - Blood Angels" gameSystemId="sys-352e-adc2-7639-d6a9" gameSystemRevision="1" revision="47" battleScribeVersion="2.03" type="catalogue" authorName="Acebaur">
   <catalogueLinks>
     <catalogueLink type="catalogue" name="Imperium - Space Marines" id="abd0-8ebd-6fbd-2d94" targetId="e0af-67df-9d63-8fb7" importRootEntries="true"/>
     <catalogueLink type="catalogue" name="Imperium - Imperial Knights - Library" id="9c08-8ffc-d746-7384" targetId="1b6d-dc06-5db9-c7d1" importRootEntries="true"/>
@@ -4025,6 +4025,7 @@ You can attach this model to one of the above units, even if one Captain, Chapt
     <selectionEntry type="model" import="true" name="Death Company Captain" hidden="false" id="4743-6dc9-fda7-0a8c">
       <infoLinks>
         <infoLink name="Invulnerable Save" id="e4b7-a76f-3668-bbac" hidden="false" type="profile" targetId="db19-dee7-9530-ef0e"/>
+        <infoLink name="Black Rage" id="3565-0ac7-f0dd-ad20" hidden="false" type="profile" targetId="3e0a-31f-8be-e293"/>
       </infoLinks>
       <profiles>
         <profile name="Death Company Captain" typeId="c547-1836-d8a-ff4f" typeName="Unit" hidden="false" id="75c4-36b0-af42-362b">
@@ -4053,11 +4054,6 @@ You can attach this model to one of the above units, even if one Captain, Chapt
         <profile name="Death Vision of Sanguinius" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="b276-0bcd-8baf-3c14">
           <characteristics>
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">If this model is destroyed by a melee attack, after the attacking unit has finished making its attacks, you can roll one D6, adding 2 to the result if the attacking unit contains the enemy Warlord. On a 2-3, that enemy unit suffers D3 mortal wounds; on a 4-5, that enemy unit suffers 3 mortal wounds; on a 6+ that enemy unit suffers D3+3 mortal wounds.</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Black Rage" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="b870-b3ce-57a6-7655">
-          <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time this model makes a melee attack, you can re-roll the Hit roll. While this model&apos;s unit is not within 12&quot; of one or more friendly Chaplain models, it cannot be selected to Fall Back and its Objective Control characteristic is 0.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -4145,6 +4141,7 @@ You can attach this model to one of the above units, even if one Captain, Chapt
     <selectionEntry type="model" import="true" name="Death Company Captain with Jump Pack" hidden="false" id="2574-a949-ae3f-58c2">
       <infoLinks>
         <infoLink name="Invulnerable Save" id="2885-4ff2-a92d-00c5" hidden="false" type="profile" targetId="db19-dee7-9530-ef0e"/>
+        <infoLink name="Black Rage" id="a7b7-85cc-dcb8-a4d7" hidden="false" type="profile" targetId="3e0a-31f-8be-e293"/>
       </infoLinks>
       <profiles>
         <profile name="Death Vision of Sanguinius" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="165c-259e-fbfe-4298">
@@ -4172,11 +4169,6 @@ You can attach this model to one of the above units, even if one Captain, Chapt
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">This model can be attached to the following units:
 
 ■ Death Company Marines with Jump Packs</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Black Rage" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="9a02-63f7-a140-1526">
-          <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time this model makes a melee attack, you can re-roll the Hit roll. While this model&apos;s unit is not within 12&quot; of one or more friendly Chaplain models, it cannot be selected to Fall Back and its Objective Control characteristic is 0.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -4815,11 +4807,6 @@ You can attach this model to one of the above units, even if one Captain, Chapt
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">In your opponent&apos;s Shooting phase, each time an enemy unit has shot, if this model was hit by one or more of those attacks, it can make a Driven by Fury move. To do so, roll one D6 and add 2 to the roll; this model moves a number of inches up to the result, but must finish as close as possible to the closest enemy unit [excluding Aircraft]. A model cannot make a Driven by Fury move while it is Battle-shocked or within Engagement Range of one or more enemy units, and can only make one Driven by Fury move per phase.</characteristic>
           </characteristics>
         </profile>
-        <profile name="Black Rage" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="eadd-9d93-1829-14d1">
-          <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time this model makes a melee attack, you can re-roll the Hit roll. While this model&apos;s unit is not within 12&quot; of one or more friendly Chaplain models, it cannot be selected to Fall Back and its Objective Control characteristic is 0.</characteristic>
-          </characteristics>
-        </profile>
       </profiles>
       <infoLinks>
         <infoLink name="Deadly Demise" id="5222-55a7-586c-77c6" hidden="false" type="rule" targetId="b68a-5ded-65ac-98c">
@@ -4833,6 +4820,7 @@ You can attach this model to one of the above units, even if one Captain, Chapt
           </modifiers>
         </infoLink>
         <infoLink name="Damaged: 1-4 Wounds Remaining" id="5841-c934-8d28-38b1" hidden="false" type="profile" targetId="ee64-aaaf-75df-8da9"/>
+        <infoLink name="Black Rage" id="df74-70ee-c1e9-644a" hidden="false" type="profile" targetId="3e0a-31f-8be-e293"/>
       </infoLinks>
       <entryLinks>
         <entryLink import="true" name="Crusade" hidden="false" id="83a9-b6bb-2e6b-5fa1" type="selectionEntryGroup" targetId="0b9e-c615-13b4-9302" sortIndex="1"/>
@@ -5152,7 +5140,7 @@ If a Character unit from your army with the Leader ability can be attached to a
   <sharedProfiles>
     <profile name="Black Rage" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="3e0a-31f-8be-e293">
       <characteristics>
-        <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time a model in this unit makes a melee attack, you can re-roll the Hit roll. While this unit is not within 6&quot; of one or more friendly BLOOD ANGEL CHARACTER models, or 12&quot; of one or more friendly Chaplain models, it cannot be selected to Fall Back and the Objective Control characteristic of models in this unit is 0.</characteristic>
+        <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time this model makes a melee attack, you can re-roll the Hit roll. While this model&apos;s unit is not within 6&quot; of one or more friendly BLOOD ANGEL CHARACTER models, or 12&quot; of one or more friendly Chaplain models, it cannot be selected to Fall Back and the Objective Control characteristic of models in this unit is 0.</characteristic>
       </characteristics>
     </profile>
     <profile name="Visions of Heresy" hidden="false" id="6b69-8f10-6d74-706c" typeName="Abilities" typeId="9cc3-6d83-4dd3-9b64">


### PR DESCRIPTION
Units with incorrect Black Rage rules text:
 - Death Company Captain
 - Death Company Captain with Jump Pack
 - Death Company Dreadnought

These units were using an unlinked profile for Black Rage, rather than the existing Black Rage linked profile which contained the latest dataslate rules text. Replaced these unlinked profiles with the linked profile on the aforementioned units