### PR TITLE
Add new Wolf Scouts datasheet for Space Wolves

### DIFF
--- a/Imperium - Space Wolves.cat
+++ b/Imperium - Space Wolves.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="94bb-3284-ee14-57a1" name="Imperium - Adeptus Astartes - Space Wolves" gameSystemId="sys-352e-adc2-7639-d6a9" gameSystemRevision="1" revision="63" battleScribeVersion="2.03" type="catalogue" authorName="Acebaur/Mad Spy">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="94bb-3284-ee14-57a1" name="Imperium - Adeptus Astartes - Space Wolves" gameSystemId="sys-352e-adc2-7639-d6a9" gameSystemRevision="1" revision="64" battleScribeVersion="2.03" type="catalogue" authorName="Acebaur/Mad Spy/Manbeardo">
   <catalogueLinks>
     <catalogueLink type="catalogue" name="Imperium - Space Marines" id="cb5b-3605-7522-c561" targetId="e0af-67df-9d63-8fb7" importRootEntries="true"/>
     <catalogueLink type="catalogue" name="Imperium - Imperial Knights - Library" id="2e06-13ae-6789-b591" targetId="1b6d-dc06-5db9-c7d1" importRootEntries="true"/>
@@ -5144,11 +5144,6 @@ You can attach this model to the above unit even if one Captain or Chapter Mast
             <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Once per turn, when an enemy unit ends a Normal, Advance or Fall Back move within 9&quot; of this unit, it can make a Normal move of up to D6&quot;</characteristic>
           </characteristics>
         </profile>
-        <profile name="Hunting Hounds" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="2b92-25f9-4952-213b">
-          <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this unit is within 6&quot; of one or more SPACE WOLVES CHARACTER models (excluding WULFEN models), if this unit is not Battle-shocked, models in it have an Objective Control characteristic of 1</characteristic>
-          </characteristics>
-        </profile>
       </profiles>
       <modifiers>
         <modifier type="set" value="80" field="51b2-306e-1021-d207">
@@ -5159,6 +5154,7 @@ You can attach this model to the above unit even if one Captain or Chapter Mast
       </modifiers>
       <infoLinks>
         <infoLink name="Oath of Moment" hidden="false" type="rule" id="c1d5-a1f4-d62d-a1ad" targetId="3b76-4053-ece9-6e7d"/>
+        <infoLink name="Hunting Hounds" id="1f4e-20e1-cc9a-2c89" hidden="false" type="profile" targetId="6631-e75e-a519-a444"/>
       </infoLinks>
       <entryLinks>
         <entryLink import="true" name="Crusade" hidden="false" id="d1c4-bce5-ff9c-ed33" type="selectionEntryGroup" targetId="9a99-f13c-a667-e698" sortIndex="1"/>
@@ -9923,14 +9919,10 @@ Strategic Reserves.</characteristic>
 a Transport</characteristic>
           </characteristics>
         </profile>
-        <profile name="Hunting Hounds" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="90e0-d8ee-abf5-5cab">
-          <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this unit is within 6&quot; of one or more friendly SPACE WOLVES CHARACTER models (excluding WULFEN models), if this unit is not Battle-shocked, HUNTING WOLVES models in it have an Objective Control characteristic of 1</characteristic>
-          </characteristics>
-        </profile>
       </profiles>
       <infoLinks>
         <infoLink name="Oath of Moment" id="616f-1f4d-3510-a734" hidden="false" type="rule" targetId="3b76-4053-ece9-6e7d"/>
+        <infoLink name="Hunting Hounds" id="e6d7-d47e-d1cb-70ad" hidden="false" type="profile" targetId="6631-e75e-a519-a444"/>
       </infoLinks>
       <selectionEntryGroups>
         <selectionEntryGroup name="Wolf Guard Headtakers" id="98a0-3e57-241e-8135" hidden="false" sortIndex="1">
@@ -10276,14 +10268,10 @@ a Transport</characteristic>
 a Transport</characteristic>
           </characteristics>
         </profile>
-        <profile name="Hunting Hounds" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="61fa-620a-da41-941c">
-          <characteristics>
-            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this unit is within 6&quot; of one or more friendly SPACE WOLVES CHARACTER models (excluding WULFEN models), if this unit is not Battle-shocked, HUNTING WOLVES models in it have an Objective Control characteristic of 1</characteristic>
-          </characteristics>
-        </profile>
       </profiles>
       <infoLinks>
         <infoLink name="Oath of Moment" id="f5d6-cd94-3675-4834" hidden="false" type="rule" targetId="3b76-4053-ece9-6e7d"/>
+        <infoLink name="Hunting Hounds" id="1429-4aac-ae87-57bd" hidden="false" type="profile" targetId="6631-e75e-a519-a444"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink targetId="cf47-a0d7-7207-29dc" id="b8f1-229a-d7a0-323a" primary="true" name="Infantry"/>
@@ -10636,6 +10624,318 @@ a Transport</characteristic>
         <categoryLink name="Hunting Wolves" hidden="false" id="47ca-bfb6-8c7c-84ec" targetId="a41f-0ee2-27ea-2e31" primary="false"/>
       </categoryLinks>
     </selectionEntry>
+    <selectionEntry type="unit" import="true" name="Wolf Scouts" hidden="false" id="20ab-dd9e-6beb-948e">
+      <costs>
+        <cost name="pts" typeId="51b2-306e-1021-d207" value="105"/>
+        <cost name="Crusade Points" typeId="b03b-c239-15a5-da55" value="0"/>
+        <cost name="Crusade: Battle Honours" typeId="75bb-ded1-c86d-bdf0" value="0"/>
+        <cost name="Crusade: Experience" typeId="a623-fe74-1d33-cddf" value="0"/>
+        <cost name="Crusade: Weapon Modifications" typeId="716d-91b7-d55a-1022" value="0"/>
+        <cost name="Blackstone Fragments" typeId="ac6b-ced3-9b5e-9a6e" value="0"/>
+        <cost name="Honour Points" typeId="8135-9a2f-6627-09e2" value="0"/>
+        <cost name="Relic Fragments" typeId="0ece-6541-4662-ece2" value="0"/>
+      </costs>
+      <categoryLinks>
+        <categoryLink targetId="cf47-a0d7-7207-29dc" id="8055-1cff-2ae1-16d1" primary="true" name="Infantry"/>
+        <categoryLink targetId="5a61-81ac-eb7c-a87e" id="35f5-4d99-a08a-e3f7" primary="false" name="Grenades"/>
+        <categoryLink targetId="6df-937-16bc-8c1a" id="165d-0c59-a0a0-593e" primary="false" name="Smoke"/>
+        <categoryLink targetId="7295-ed65-8ff4-7a5f" id="099c-5cb0-7b90-9c87" primary="false" name="Phobos"/>
+        <categoryLink targetId="aff3-d6a3-2a95-9dc" id="77df-f832-4d9a-c58c" primary="false" name="Imperium"/>
+        <categoryLink targetId="be72-390b-33b7-d52d" id="6c45-e8fa-45de-cdca" primary="false" name="Wolf Scouts"/>
+        <categoryLink targetId="6e7-40c-58d9-e402" id="60b0-b3f2-8626-ac57" primary="false" name="Faction: Adeptus Astartes"/>
+        <categoryLink targetId="a0d9-c115-2a-8330" id="1159-90e1-f9d4-44be" primary="false" name="Faction: Space Wolves"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup name="5-10 Wolf Scouts" id="bf84-a56d-8116-9dc7" hidden="false" sortIndex="2">
+          <selectionEntries>
+            <selectionEntry type="model" import="true" name="Wolf Scout w/ plasma pistol" hidden="false" id="9742-7516-1e3e-f998" sortIndex="2" defaultAmount="1">
+              <constraints>
+                <constraint type="max" value="9" field="selections" scope="parent" shared="true" id="9e33-292c-164f-430c"/>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="2a1b-ebe1-a413-d5a5" includeChildSelections="false"/>
+              </constraints>
+              <entryLinks>
+                <entryLink import="true" name="Combat blade" hidden="false" id="c139-cd5e-0b57-9b78" type="selectionEntry" targetId="4af2-96a7-81c5-5a19"/>
+                <entryLink import="true" name="Plasma pistol" hidden="false" id="f5c0-ed9a-7b22-55d0" type="selectionEntry" targetId="7b6b-13c7-2973-44c0">
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f420-423b-2914-8a7f" includeChildSelections="false"/>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8158-703a-54a4-068d" includeChildSelections="false"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntry>
+            <selectionEntry type="model" import="true" name="Wolf Scout w/ plasma gun" hidden="false" id="a2ec-293a-2d0b-c1b6" sortIndex="3" defaultAmount="1">
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="617d-b824-01ae-1c16" includeChildSelections="false"/>
+              </constraints>
+              <entryLinks>
+                <entryLink import="true" name="Combat blade" hidden="false" id="146e-ddce-14d0-b705" type="selectionEntry" targetId="4af2-96a7-81c5-5a19"/>
+                <entryLink import="true" name="Plasma gun" hidden="false" id="88b4-d357-3fd0-4c15" type="selectionEntry" targetId="6c84-62ea-477c-609c"/>
+              </entryLinks>
+            </selectionEntry>
+            <selectionEntry type="model" import="true" name="Wolf Scout w/ haywire mine" hidden="false" id="85cc-0b04-abcd-f47e" sortIndex="4" defaultAmount="1">
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2166-0584-d6a2-1eb0" includeChildSelections="false"/>
+              </constraints>
+              <entryLinks>
+                <entryLink import="true" name="Combat blade" hidden="false" id="2b03-d106-e451-bb9d" type="selectionEntry" targetId="4af2-96a7-81c5-5a19" defaultAmount="1"/>
+                <entryLink import="true" name="Plasma pistol" hidden="false" id="6740-b5a4-a63c-5efe" type="selectionEntry" targetId="7b6b-13c7-2973-44c0" defaultAmount="1">
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="ff3b-13ed-962f-1eb3" includeChildSelections="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="daa7-c498-cb4d-0a71" includeChildSelections="false"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <selectionEntries>
+                <selectionEntry type="upgrade" import="true" name="Haywire Mine" hidden="false" id="1b2d-47cd-2ea4-c70e" defaultAmount="1">
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2fed-e3a7-fb43-ca85"/>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="ce2e-66f5-b97d-dd16" includeChildSelections="false"/>
+                  </constraints>
+                  <profiles>
+                    <profile name="Haywire Mine" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="5a18-589f-38a7-fd07">
+                      <characteristics>
+                        <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Once per battle, at the start of any phase, you can select one enemy unit within 3&quot; of the bearer and roll one D6: on a 2+, that enemy unit suffers D3 mortal wounds, or 2D3 mortal wounds instead if it is a Vehicle unit.</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntry>
+            <selectionEntry type="model" import="true" name="Wolf Scout w/ runic stave" hidden="false" id="73cf-46cf-f98b-a142" sortIndex="5" defaultAmount="1">
+              <entryLinks>
+                <entryLink import="true" name="Bolt pistol" hidden="false" id="77e2-108e-fde0-9ea7" type="selectionEntry" targetId="18b0-8c2-173f-5" defaultAmount="1">
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="73c1-bad6-d134-0daa" includeChildSelections="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="86b0-0dc7-5bb1-e4bb" includeChildSelections="false"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="0b3c-4ea9-cc5c-499b" includeChildSelections="false"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry type="upgrade" import="true" name="Runic stave" hidden="false" id="e8cc-0b0a-8281-d27a" defaultAmount="1">
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="1508-464f-ed45-d437" includeChildSelections="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="60bf-4620-dfc0-fae4" includeChildSelections="false"/>
+                  </constraints>
+                  <profiles>
+                    <profile name="Runic stave" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="4bb4-af91-cdb5-01cd">
+                      <characteristics>
+                        <characteristic name="Range" typeId="914c-b413-91e3-a132"/>
+                        <characteristic name="A" typeId="2337-daa1-6682-b110">3</characteristic>
+                        <characteristic name="WS" typeId="95d1-95f-45b4-11d6">3+</characteristic>
+                        <characteristic name="S" typeId="ab33-d393-96ce-ccba">6</characteristic>
+                        <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-1</characteristic>
+                        <characteristic name="D" typeId="3254-9fe6-d824-513e">D3</characteristic>
+                        <characteristic name="Keywords" typeId="893f-9000-ccf7-648e">Psychic</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Thunderclap" hidden="false" id="a94b-12bb-11fd-96c2" defaultAmount="1">
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b234-bf34-b657-baa5" includeChildSelections="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d359-382b-36c7-bbe9" includeChildSelections="false"/>
+                  </constraints>
+                  <profiles>
+                    <profile name="Thunderclap" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="48f9-161a-b7aa-02f0">
+                      <characteristics>
+                        <characteristic name="Range" typeId="9896-9419-16a1-92fc">12&quot;</characteristic>
+                        <characteristic name="A" typeId="3bb-c35f-f54-fb08">D3</characteristic>
+                        <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                        <characteristic name="S" typeId="2229-f494-25db-c5d3">5</characteristic>
+                        <characteristic name="AP" typeId="9ead-8a10-520-de15">-1</characteristic>
+                        <characteristic name="D" typeId="a354-c1c8-a745-f9e3">2</characteristic>
+                        <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Blast, Psychic</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <infoLinks>
+                    <infoLink name="Blast" id="e36f-95a1-6c1c-c7a4" hidden="false" type="rule" targetId="6c1f-1cf7-ff25-c99e"/>
+                  </infoLinks>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntry>
+            <selectionEntry type="model" import="true" name="Wolf Scout w/ instigator bolt carbine" hidden="false" id="4b5f-bad2-bb91-8701" sortIndex="6" defaultAmount="0">
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5d1f-05fd-5c05-d815" includeChildSelections="false"/>
+              </constraints>
+              <entryLinks>
+                <entryLink import="true" name="Combat blade" hidden="false" id="480d-bb00-ad67-9fb1" type="selectionEntry" targetId="4af2-96a7-81c5-5a19" defaultAmount="1"/>
+              </entryLinks>
+              <selectionEntries>
+                <selectionEntry type="upgrade" import="true" name="Instigator bolt carbine" hidden="false" id="f4ba-6f21-0d6b-66f8" defaultAmount="1">
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="f5cb-1b63-2c37-1eda" includeChildSelections="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2d91-4be5-e4ce-4a6c" includeChildSelections="false"/>
+                  </constraints>
+                  <profiles>
+                    <profile name="Instigator bolt carbine" typeId="f77d-b953-8fa4-b762" typeName="Ranged Weapons" hidden="false" id="222c-dfc1-7c9c-2238">
+                      <characteristics>
+                        <characteristic name="Range" typeId="9896-9419-16a1-92fc">24&quot;</characteristic>
+                        <characteristic name="A" typeId="3bb-c35f-f54-fb08">2</characteristic>
+                        <characteristic name="BS" typeId="94d-8a98-cf90-183e">3+</characteristic>
+                        <characteristic name="S" typeId="2229-f494-25db-c5d3">4</characteristic>
+                        <characteristic name="AP" typeId="9ead-8a10-520-de15">-2</characteristic>
+                        <characteristic name="D" typeId="a354-c1c8-a745-f9e3">2</characteristic>
+                        <characteristic name="Keywords" typeId="7f1b-8591-2fcf-d01c">Precision</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <infoLinks>
+                    <infoLink name="Precision" id="ba01-a8ef-b7e8-e4fa" hidden="false" type="rule" targetId="9143-31ae-e0a6-6007"/>
+                  </infoLinks>
+                </selectionEntry>
+              </selectionEntries>
+              <modifiers>
+                <modifier type="set" value="0" field="5d1f-05fd-5c05-d815">
+                  <conditions>
+                    <condition type="lessThan" value="9" field="selections" scope="20ab-dd9e-6beb-948e" childId="model" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </selectionEntry>
+            <selectionEntry type="model" import="true" name="Wolf Scout Pack Leader" hidden="false" id="edee-f812-fbe1-f7df" defaultAmount="1" sortIndex="1">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6881-d6cc-63bb-0da2"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5a4c-6e8a-276c-d9d4"/>
+              </constraints>
+              <entryLinks>
+                <entryLink import="true" name="Power weapon" hidden="false" id="71ec-63f2-44ed-fc28" type="selectionEntry" targetId="4c25-8015-9ae1-fbed" defaultAmount="1">
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="358c-8fa6-2b0c-1394" includeChildSelections="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3ab8-9abf-8c7d-e4bb" includeChildSelections="false"/>
+                  </constraints>
+                </entryLink>
+                <entryLink import="true" name="Plasma pistol" hidden="false" id="4896-1181-09b5-4c69" type="selectionEntry" targetId="7b6b-13c7-2973-44c0" defaultAmount="1">
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b458-5d44-3230-cb05" includeChildSelections="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="200c-9fd8-4a59-3d54" includeChildSelections="false"/>
+                  </constraints>
+                </entryLink>
+                <entryLink import="true" name="Terminator Honours upgrade" hidden="false" id="2f07-0244-d396-7456" type="selectionEntry" targetId="e7f9-66f5-9b9e-c587"/>
+              </entryLinks>
+            </selectionEntry>
+          </selectionEntries>
+          <profiles>
+            <profile name="Wolf Scouts" typeId="c547-1836-d8a-ff4f" typeName="Unit" hidden="false" id="d814-868b-da73-281e">
+              <characteristics>
+                <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">7&quot;</characteristic>
+                <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">4</characteristic>
+                <characteristic name="SV" typeId="450-a17e-9d5e-29da">3+</characteristic>
+                <characteristic name="W" typeId="750a-a2ec-90d3-21fe">2</characteristic>
+                <characteristic name="LD" typeId="58d2-b879-49c7-43bc">6+</characteristic>
+                <characteristic name="OC" typeId="bef7-942a-1a23-59f8">1</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <constraints>
+            <constraint type="max" value="10" field="selections" scope="parent" shared="true" id="bae0-b3f7-c842-7fa3" includeChildSelections="false"/>
+            <constraint type="min" value="5" field="selections" scope="parent" shared="true" id="701d-5ea4-92ba-b302" includeChildSelections="false"/>
+          </constraints>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink import="true" name="Crusade" hidden="false" id="b25b-bf5e-6129-6a6e" type="selectionEntryGroup" targetId="9a99-f13c-a667-e698" sortIndex="1"/>
+      </entryLinks>
+      <selectionEntries>
+        <selectionEntry type="model" import="true" name="Hunting Wolves" hidden="false" id="108a-0583-4e64-7c90" sortIndex="3" defaultAmount="1">
+          <modifiers>
+            <modifier type="set" value="1" field="05eb-435d-6e47-77f2">
+              <conditions>
+                <condition type="lessThan" value="7" field="selections" scope="20ab-dd9e-6beb-948e" childId="model" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="e86a-405c-ca01-f3ac" includeChildSelections="false"/>
+            <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="05eb-435d-6e47-77f2" includeChildSelections="false"/>
+          </constraints>
+          <infoLinks>
+            <infoLink name="Hunting Hounds" id="8275-a0ee-c4f8-44c0" hidden="false" type="profile" targetId="6631-e75e-a519-a444"/>
+          </infoLinks>
+          <profiles>
+            <profile name="Hunting Wolves" typeId="c547-1836-d8a-ff4f" typeName="Unit" hidden="false" id="d6fe-02e7-ff5a-db47">
+              <characteristics>
+                <characteristic name="M" typeId="e703-ecb6-5ce7-aec1">10&quot;</characteristic>
+                <characteristic name="T" typeId="d29d-cf75-fc2d-34a4">4</characteristic>
+                <characteristic name="SV" typeId="450-a17e-9d5e-29da">6+</characteristic>
+                <characteristic name="W" typeId="750a-a2ec-90d3-21fe">1</characteristic>
+                <characteristic name="LD" typeId="58d2-b879-49c7-43bc">8+</characteristic>
+                <characteristic name="OC" typeId="bef7-942a-1a23-59f8">0</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Teeth and claws" hidden="false" id="33f2-c040-611a-ada5" defaultAmount="1">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="9c81-dfc1-66f8-20f5" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="97c6-c1de-6659-5a48" includeChildSelections="false"/>
+              </constraints>
+              <profiles>
+                <profile name="Teeth and claws" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="f686-88a5-3c24-28d7">
+                  <characteristics>
+                    <characteristic name="Range" typeId="914c-b413-91e3-a132"/>
+                    <characteristic name="A" typeId="2337-daa1-6682-b110">2</characteristic>
+                    <characteristic name="WS" typeId="95d1-95f-45b4-11d6">4+</characteristic>
+                    <characteristic name="S" typeId="ab33-d393-96ce-ccba">4</characteristic>
+                    <characteristic name="AP" typeId="41a0-1301-112a-e2f2">0</characteristic>
+                    <characteristic name="D" typeId="3254-9fe6-d824-513e">1</characteristic>
+                    <characteristic name="Keywords" typeId="893f-9000-ccf7-648e"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntry>
+      </selectionEntries>
+      <constraints>
+        <constraint type="max" value="3" field="selections" scope="roster" shared="true" id="b250-a2a4-d5a1-ed5f" includeChildSelections="true" includeChildForces="true"/>
+        <constraint type="min" value="0" field="716d-91b7-d55a-1022" scope="self" shared="true" id="26cc-2267-a020-8816" includeChildSelections="true"/>
+        <constraint type="max" value="3" field="75bb-ded1-c86d-bdf0" scope="self" shared="true" id="1126-8e1f-e0cf-6aa4" includeChildSelections="false"/>
+        <constraint type="max" value="0" field="716d-91b7-d55a-1022" scope="self" shared="true" id="af67-5eb9-bc90-3364" includeChildSelections="true"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="210" field="51b2-306e-1021-d207">
+          <conditions>
+            <condition type="greaterThan" value="6" field="selections" scope="20ab-dd9e-6beb-948e" childId="model" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <profiles>
+        <profile name="Deadly Stalkers" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="f4bb-7cc9-9573-078e">
+          <characteristics>
+            <characteristic name="Description" typeId="9b8f-694b-e5e-b573">Each time a model in this unit makes an attack that targets an enemy unit, if there are no other units from your opponent’s army within 6&quot; of that target, add 1 to the Wound roll.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink name="Oath of Moment" id="ba4a-434a-515f-994e" hidden="false" type="rule" targetId="3b76-4053-ece9-6e7d"/>
+      </infoLinks>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Combat blade" hidden="false" id="4af2-96a7-81c5-5a19" collective="true">
+      <categoryLinks>
+        <categoryLink targetId="ccdd-3987-11ed-90cd" id="348b-ee9c-aa92-d99b" primary="false" name="Melee Weapon"/>
+      </categoryLinks>
+      <profiles>
+        <profile name="Combat blade" typeId="8a40-4aaa-c780-9046" typeName="Melee Weapons" hidden="false" id="b533-fd30-e475-4d96">
+          <characteristics>
+            <characteristic name="Range" typeId="914c-b413-91e3-a132"/>
+            <characteristic name="A" typeId="2337-daa1-6682-b110">4</characteristic>
+            <characteristic name="WS" typeId="95d1-95f-45b4-11d6">3+</characteristic>
+            <characteristic name="S" typeId="ab33-d393-96ce-ccba">4</characteristic>
+            <characteristic name="AP" typeId="41a0-1301-112a-e2f2">-1</characteristic>
+            <characteristic name="D" typeId="3254-9fe6-d824-513e">1</characteristic>
+            <characteristic name="Keywords" typeId="893f-9000-ccf7-648e"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="c839-61c8-00b3-a9db" includeChildSelections="false"/>
+        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7585-ab6a-39f6-8892" includeChildSelections="false"/>
+      </constraints>
+    </selectionEntry>
   </sharedSelectionEntries>
   <categoryEntries>
     <categoryEntry name="Logan Grimnar" hidden="false" id="48a0-9386-4930-6a62">
@@ -10850,6 +11150,7 @@ a Transport</characteristic>
     <entryLink import="true" name="Wolf Guard Headtakers" hidden="false" id="3e0e-a813-a6ff-e8e9" type="selectionEntry" targetId="0f93-6850-8f14-a351">
       <comment>Crusade variant</comment>
     </entryLink>
+    <entryLink import="true" name="Wolf Scouts" hidden="false" id="6b62-a0d4-7e84-afe6" type="selectionEntry" targetId="20ab-dd9e-6beb-948e"/>
   </entryLinks>
   <sharedInfoGroups>
     <infoGroup name="Logan" hidden="false" id="976-2d16-9324-f92">
@@ -10886,4 +11187,11 @@ a Transport</characteristic>
       <description>While this unit is within 6&quot; of one or more friendly SPACE WOLVES CHARACTER models (Excluding WULFEN models) or within 12&quot; of one or more friendly WOLF PRIEST models, if it is not Battle-shocked, add 1 to the Objective Control characteristic of INFANTRY models in it and add 3 to the Objective Control characteristic of VEHICLE models in it.</description>
     </rule>
   </sharedRules>
+  <sharedProfiles>
+    <profile name="Hunting Hounds" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="6631-e75e-a519-a444">
+      <characteristics>
+        <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this unit is within 6&quot; of one or more SPACE WOLVES CHARACTER models (excluding WULFEN models), if this unit is not Battle-shocked, models in it have an Objective Control characteristic of 1</characteristic>
+      </characteristics>
+    </profile>
+  </sharedProfiles>
 </catalogue>


### PR DESCRIPTION
Implementation of #5733

I also turned the Hunting Hounds ability into a shared profile since there are now 3 (4 including the crusade variant of Headtakers) datasheets on which that ability appears identically.


https://github.com/user-attachments/assets/f03265c0-cf79-4350-9717-e36c71845a68

