### PR TITLE
Custodes - Adjusted points for munitorum field manual 12-10-2025

### DIFF
--- a/Imperium - Adeptus Custodes.cat
+++ b/Imperium - Adeptus Custodes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="1f19-6509-d906-ca10" name="Imperium - Adeptus Custodes" revision="82" battleScribeVersion="2.03" library="false" gameSystemId="sys-352e-adc2-7639-d6a9" gameSystemRevision="1" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" id="1f19-6509-d906-ca10" name="Imperium - Adeptus Custodes" revision="83" battleScribeVersion="2.03" library="false" gameSystemId="sys-352e-adc2-7639-d6a9" gameSystemRevision="1" type="catalogue">
   <categoryEntries>
     <categoryEntry id="a43a-4cf6-6443-f48e" name="Aleya" hidden="false"/>
     <categoryEntry id="5386-42fc-f4d0-7d64" name="Allarus Custodians" hidden="false"/>


### PR DESCRIPTION
Not sure if we can contribute with it. but I tried doing my first one for the golden boys. Let me know if something seems wrong :)

Changes:

Custodian Guards
4 models 160  -> 150
5 models 200  -> 190

Allarus Custodians
2 models 120 -> 110 pts
3 models 180 -> 165 pts
5 models 300 -> 275 pts
6 models 330 -> 330 pts

Vigilators
4 models 50 -> 45 pts
5 models 65 -> 55 pts
9 models 100 -> 90 pts
10 models 110 -> 100 pts

Witchseekers
4 models 50 -> 45 pts
5 models 65 -> 55 pts
9 models  115 ->  90 pts
10 models 125 -> 100 pts
