### PR TITLE
Fixing Blood Angels association names

### DIFF
--- a/Imperium - Blood Angels.cat
+++ b/Imperium - Blood Angels.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="4ef9-15ce-e3e6-36de" name="Imperium - Adeptus Astartes - Blood Angels" gameSystemId="sys-352e-adc2-7639-d6a9" gameSystemRevision="1" revision="76" battleScribeVersion="2.03" type="catalogue" authorName="Acebaur">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="4ef9-15ce-e3e6-36de" name="Imperium - Adeptus Astartes - Blood Angels" gameSystemId="sys-352e-adc2-7639-d6a9" gameSystemRevision="1" revision="77" battleScribeVersion="2.03" type="catalogue" authorName="Acebaur">
   <catalogueLinks>
     <catalogueLink type="catalogue" name="Imperium - Space Marines" id="abd0-8ebd-6fbd-2d94" targetId="e0af-67df-9d63-8fb7" importRootEntries="true"/>
     <catalogueLink type="catalogue" name="Imperium - Imperial Knights - Library" id="9c08-8ffc-d746-7384" targetId="1b6d-dc06-5db9-c7d1" importRootEntries="true"/>
@@ -3318,7 +3318,7 @@ horizontally away from all enemy models.</characteristic>
             </profile>
           </profiles>
           <associations>
-            <association min="1" max="1" scope="parent" childId="8e33-50a5-d053-ee15" name="New Association" id="9621-656a-ffa9-4744"/>
+            <association min="1" max="1" scope="parent" childId="8e33-50a5-d053-ee15" name="Sanguinary Banner" id="9621-656a-ffa9-4744"/>
           </associations>
         </selectionEntry>
       </selectionEntries>
@@ -4995,7 +4995,7 @@ You can attach this model to one of the above units, even if one Captain, Chapt
             </modifier>
           </modifiers>
           <associations>
-            <association min="1" max="1" scope="parent" childId="e047-0de8-e48f-d8cd" name="New Association" id="d062-9c01-d4ee-b2d0"/>
+            <association min="1" max="1" scope="parent" childId="e047-0de8-e48f-d8cd" name="Astartes Grenade Launcher" id="d062-9c01-d4ee-b2d0"/>
           </associations>
         </selectionEntry>
       </selectionEntries>


### PR DESCRIPTION
This should fix a UI issue where the selection for which model has the Sanguinary Banner is incorrect.
