### PR TITLE
fix: Typo in Space Wolves data BSData\Imperium - Space Marines.cat -

### DIFF
--- a/Imperium - Space Marines.cat
+++ b/Imperium - Space Marines.cat
@@ -41455,7 +41455,7 @@ Enhancement. When it does, until the start of your next Command phase, all Ange
               <profiles>
                 <profile name="Wolf-Touched" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="e726-4c28-04f6-2848">
                   <characteristics>
-                    <characteristic name="Description" typeId="9b8f-694b-e5e-b573">SPACE WOVLES model only. Add 2&quot; to the Move characteristic of the bearer. In the Declare Battle Formations step, the bearer can be attached to a WULFEN INFANTRY unit</characteristic>
+                    <characteristic name="Description" typeId="9b8f-694b-e5e-b573">SPACE WOLVES model only. Add 2&quot; to the Move characteristic of the bearer. In the Declare Battle Formations step, the bearer can be attached to a WULFEN INFANTRY unit</characteristic>
                   </characteristics>
                 </profile>
               </profiles>


### PR DESCRIPTION
Fixes #6748

Corrects a typo in the Wolf-Touched ability description within `Imperium - Space Marines.cat` at line 41458. The characteristic value for the `Wolf-Touched` profile (id `e726-4c28-04f6-2848`) contained "SPACE WOVLES" instead of "SPACE WOLVES" -- a transposition error in the unit keyword reference. Changes the malformed string to the correct faction keyword in the `Description` characteristic under `typeId 9b8f-694b-e5e-b573`. Verified by direct diff inspection confirming the single-character transposition is resolved and no other occurrences of the typo exist in the file.