### PR TITLE
"and" to "an" - Spelling mistage for "Recount the Deeds of the Saints"

### DIFF
--- a/Imperium - Adepta Sororitas.cat
+++ b/Imperium - Adepta Sororitas.cat
@@ -128,7 +128,7 @@
             </profile>
             <profile name="Recount the Deeds of the Saints" typeId="9cc3-6d83-4dd3-9b64" typeName="Abilities" hidden="false" id="aa7c-b9b-2657-ddbd">
               <characteristics>
-                <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this unit is leading a unit and contains and Agathae Dolan model, each time that unit destroys an enemy unit, you gain 1 Miracle dice. When that Agathae Dolan model is destroyed, you gain D3 Miracle dice.</characteristic>
+                <characteristic name="Description" typeId="9b8f-694b-e5e-b573">While this unit is leading a unit and contains an Agathae Dolan model, each time that unit destroys an enemy unit, you gain 1 Miracle dice. When that Agathae Dolan model is destroyed, you gain D3 Miracle dice.</characteristic>
               </characteristics>
             </profile>
           </profiles>


### PR DESCRIPTION
Fixes #7387